### PR TITLE
Turn HTML table into Markdown

### DIFF
--- a/docs/RegisteredFilterPlugins.md
+++ b/docs/RegisteredFilterPlugins.md
@@ -14,36 +14,13 @@ To register a filter please contact The HDF Helpdesk with the following informat
 
 The current policy for filter identifier assignment is as follows:
 
- <table>
-  <tr>
-    <th>Filter Identifier Values</th><th>Description</th>
-  </tr>
-  <tr>
-    <td><code>0-255</code></td>
-    <td>These values are reserved for filters predefined and
-         registered by the HDF5 library and of use to the general public.</td>
-  </tr>
-  <tr>
-    <td><code>256-511</code></td>
-    <td>Filter values in this range are intended for testing only and can be
-        temporarily used by any organization. No attempts are made to resolve
-        numbering conflicts, as all definitions are temporary.</td>
-  </tr>
-  <tr>
-    <td><code>512-32,767</code></td>
-    <td>Filter values within this range are designated for filters managed by
-        The HDF Group, but they are nominally requested, developed, and supported
-        by third parties. Please contact the
-        <a href="mailto:help@hdfgroup.org">HDF5 development team</a>
-        to reserve a value or range of values for use by your filters.</td>
-  </tr>
-  <tr>
-    <td><code>32,768-65,535</code></td>
-    <td>Filter values in this range are designated for internal company use or
-        application testing when assessing a feature. The HDF Group does not
-        track or document the use of filters within this range.</td>
-  </tr>
-  </table>
+| Filter Identifier Values | Description |
+|--------------------------|-------------|
+| `0-255`                  | These values are reserved for filters predefined and registered by the HDF5 library and of use to the general public. |
+| `256-511`                | Filter values in this range are intended for testing only and can be temporarily used by any organization. No attempts are made to resolve numbering conflicts, as all definitions are temporary. |
+| `512-32,767`             | Filter values within this range are designated for filters managed by The HDF Group, but they are nominally requested, developed, and supported by third parties. Please contact the [HDF5 development team](mailto:help@hdfgroup.org) to reserve a value or range of values for use by your filters. |
+| `32,768-65,535`          | Filter values in this range are designated for internal company use or application testing when assessing a feature. The HDF Group does not track or document the use of filters within this range. |
+
 
 List of Filters Registered with The HDF Group
 ---------------------------------------------
@@ -85,7 +62,7 @@ List of Filters Registered with The HDF Group
 |32029   |<a href="#trpx">TERSE/PROLIX</a>    |A lossless and fast compression of the diffraction data|
 |32030   |<a href="#ffmpeg">FFMPEG</a>    |A lossy compression filter based on ffmpeg video library|
 
-> [!NOTE] 
+> [!NOTE]
 > Please contact the maintainer of a filter for help with the filter/compression support in HDF5.
 
 ## <center>The Filters</center>
@@ -212,8 +189,8 @@ http://wr.informatik.uni-hamburg.de/research/projects/icomex/mafisc
 
 #### Contact Information:
 
-Nathanael Huebbe 
-Email: nathanael.huebbe at informatik dot uni-hamburg dot de 
+Nathanael Huebbe
+Email: nathanael.huebbe at informatik dot uni-hamburg dot de
 
 ##
 
@@ -272,7 +249,7 @@ Appears to be no longer available
 #### Filter ID: 32006
 
 #### Filter Description:
-All imgCIF/CBF compressions and decompressions, including Canonical, Packed, Packed Vesrsion 2, Byte Offset and Nibble Offset. 
+All imgCIF/CBF compressions and decompressions, including Canonical, Packed, Packed Vesrsion 2, Byte Offset and Nibble Offset.
 License Information: GPL and LGPL
 
 #### Contact Information:
@@ -296,7 +273,7 @@ JPEG-XR Filter for HDF5
 
 #### Contact Information:
 
-Marvin Albert 
+Marvin Albert
 Email: marvin dot albert at gmail dot com
 
 ##
@@ -569,7 +546,7 @@ This filter is used by Oxford Nanopore specifically to compress raw dna signal d
 
 streamvbyte (https://github.com/lemire/streamvbyte)
 
-zstd  (https://github.com/facebook/zstd) 
+zstd  (https://github.com/facebook/zstd)
 
 #### Contact Information:
 
@@ -651,13 +628,13 @@ Charlie Zender  (University of California, Irvine)
 
 #### Filter Description:
 
-SZ3 is a modular error-bounded lossy compression framework for scientific datasets, which allows users to customize their own compression pipeline to adapt to diverse datasets and user-requirements. Compared with SZ2 (filter id: 32017), SZ3 has integrated a more effective prediction such that its compression qualities/ratios are much higher than that of SZ2 in most of cases.  
+SZ3 is a modular error-bounded lossy compression framework for scientific datasets, which allows users to customize their own compression pipeline to adapt to diverse datasets and user-requirements. Compared with SZ2 (filter id: 32017), SZ3 has integrated a more effective prediction such that its compression qualities/ratios are much higher than that of SZ2 in most of cases.
 
 #### Filter Information:
 
 This filter is documented, implemented, and maintained in github: https://github.com/szcompressor/SZ3.
 
-License: https://github.com/szcompressor/SZ/blob/master/copyright-and-BSD-license.txt 
+License: https://github.com/szcompressor/SZ/blob/master/copyright-and-BSD-license.txt
 
 #### Contact Information:
 
@@ -675,7 +652,7 @@ Email: cappello at mcs dot anl dot gov
 
 #### Filter Description:
 
-Lossless compression algorithm optimized for digitized analog signals based on delta encoding and rice coding.  
+Lossless compression algorithm optimized for digitized analog signals based on delta encoding and rice coding.
 
 #### Filter Information:
 
@@ -684,7 +661,7 @@ This filter is documented, implemented, and maintained at: https://gitlab.com/dg
 #### Contact Information:
 
 David Mathews
-Email: david dot mathews dot 1994 at gmail dot com 
+Email: david dot mathews dot 1994 at gmail dot com
 
 ##
 
@@ -789,4 +766,3 @@ License: Under MIT License
 
 #### Contact Information:
 Cai Lab at University of Michigan: https://www.cai-lab.org
-


### PR DESCRIPTION
Reformats the HTML table to Markdown. I feel there is too much HTML markup for the amount of text.