### PR TITLE
Add a more detailed description of the LZ4 HDF5 format

### DIFF
--- a/LZ4/Additional_Legal/LICENSE
+++ b/LZ4/Additional_Legal/LICENSE
@@ -1,0 +1,67 @@
+LZ4 LICENSE:
+
+   LZ4 - Fast LZ compression algorithm
+   Header File
+   Copyright (C) 2011-2012, Yann Collet.
+   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+       * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following disclaimer
+   in the documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   You can contact the author at :
+   - LZ4 homepage : http://fastcompression.blogspot.com/p/lz4.html
+   - LZ4 source repository : http://code.google.com/p/lz4/
+
+
+HDF5 FILTER IMPLEMENTATION
+
+   License for Dectris lz4-hdf5 filter plugin
+   Copyright (C) 2011-2013, Dectris Ltd.
+   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+       * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following disclaimer
+   in the documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   You can contact the author at :
+   Dectris homepage : http://www.dectris.com
+   

--- a/LZ4/LZ4_HDF5_format.md
+++ b/LZ4/LZ4_HDF5_format.md
@@ -1,0 +1,45 @@
+# LZ4 HDF5 Format Description
+
+## Introduction
+
+This document describes the LZ4 HDF5 format used in HDF5 Filter ID: `32004`
+This is a more detailed version of [_HDF5_LZ4.pdf_](https://github.com/dectris/HDF5Plugin/blob/master/HDF5_LZ4.pdf)
+
+No client data values are required to decode this format.
+
+This format is not compatible with [LZ4 Frame](https://github.com/lz4/lz4/blob/v1.10.0/doc/lz4_Frame_format.md)
+or [LZ4 Block](https://github.com/lz4/lz4/blob/v1.10.0/doc/lz4_Block_format.md) formats, but uses the LZ4 Block format internally.
+
+## General Structure
+
+There is a 12 byte header followed by a number of blocks.
+
+Each block starts with 4 byte header containing the compressed size of the block.
+
+Blocks may be compressed or not compressed.
+Each block can be decompressed independently of the other blocks.
+
+Only the blocks required to store the original data are produced.
+If the original size is zero, there are no blocks.
+
+| Orig Size | Block Size | C Size 0 | Data 0   | (...) | C Size N | Data N   |
+|:---------:|:----------:| -------- | -------- | ----- | -------- | -------- |
+| 8 bytes   | 4 bytes    | 4 bytes  | C Size 0 |       | 4 bytes  | C Size N |
+
+### Original Size
+
+Total decompressed size stored in big endian signed 64 bit format.
+
+### Block Size
+
+Decompressed bytes per block stored in big endian signed 32 bit format.
+All blocks must have this decompressed size except the last one, which might be smaller.
+
+Block size must be greater than zero.
+
+### Compressed Size
+
+The size of the data field stored in big endian signed 32 bit format.
+
+If this value is equal to the known decompressed size of the block, the data is stored
+not compressed. Otherwise, the data is in the [LZ4 Block](https://github.com/lz4/lz4/blob/v1.10.0/doc/lz4_Block_format.md) format.

--- a/docs/RegisteredFilterPlugins.md
+++ b/docs/RegisteredFilterPlugins.md
@@ -292,7 +292,7 @@ Email: lucasvr at gmail dot com
 Filter ID: `32004`
 
 #### Description
-LZ4 is a very fast lossless compression algorithm, providing compression speed at 300 MB/s per core, scalable with multi-cores CPU. It also features an extremely fast decoder, with speeds up and beyond 1GB/s per core, typically reaching RAM speed limits on multi-core systems. For a format description of the LZ4 compression filter in HDF5, see [_HDF5_LZ4.pdf_](https://github.com/dectris/HDF5Plugin/blob/master/HDF5_LZ4.pdf).
+LZ4 is a very fast lossless compression algorithm, providing compression speed at 300 MB/s per core, scalable with multi-cores CPU. It also features an extremely fast decoder, with speeds up and beyond 1GB/s per core, typically reaching RAM speed limits on multi-core systems. For a format description of the LZ4 compression filter in HDF5, see [LZ4_HDF5_format.md](../LZ4/LZ4_HDF5_format.md).
 
 Filter specific parameters:
 
@@ -300,7 +300,7 @@ Number of `cd_values[]` parameters is one (`cd_nelmts = 1`).
 
 | `cd_values[]` | Description |
 |---|---|
-| `[0]` | Block size in bytes smaller than 1.9 GB. Default is 1 GB. (optional) |
+| `[0]` | Block size in bytes at most 2,113,929,216 bytes. Default is 1 GB. (optional) |
 
 `h5repack` example for the `--filter` option: `<objects list>:UD=32004,0,0`.
 

--- a/docs/RegisteredFilterPlugins.md
+++ b/docs/RegisteredFilterPlugins.md
@@ -292,7 +292,7 @@ Email: lucasvr at gmail dot com
 Filter ID: `32004`
 
 #### Description
-LZ4 is a very fast lossless compression algorithm, providing compression speed at 300 MB/s per core, scalable with multi-cores CPU. It also features an extremely fast decoder, with speeds up and beyond 1GB/s per core, typically reaching RAM speed limits on multi-core systems. For a format description of the LZ4 compression filter in HDF5, see [LZ4_HDF5_format.md](../LZ4/LZ4_HDF5_format.md).
+LZ4 is a very fast lossless compression algorithm, providing compression speed at 300 MB/s per core, scalable with multi-cores CPU. It also features an extremely fast decoder, with speeds up and beyond 1GB/s per core, typically reaching RAM speed limits on multi-core systems. For a format description of the LZ4 compression filter in HDF5, see [LZ4_HDF5_format.md](https://github.com/HDFGroup/hdf5_plugins/blob/master/LZ4/LZ4_HDF5_format.md).
 
 Filter specific parameters:
 


### PR DESCRIPTION
This PR adds a more detailed description of the LZ4 HDF5 format to help with #134 

I also added the original license from https://github.com/dectris/HDF5Plugin

CC @mkitti @derobins @cgohlke @t20100

Here are some links to current implementations of this filter.

https://github.com/dectris/HDF5Plugin/blob/master/h5zlz4.c
https://github.com/nexusformat/HDF5-External-Filter-Plugins/blob/master/LZ4/src/H5Zlz4.c
https://github.com/silx-kit/hdf5plugin/blob/main/src/LZ4/H5Zlz4.c
https://github.com/HDFGroup/hdf5_plugins/blob/master/LZ4/src/H5Zlz4.c
https://github.com/JuliaIO/HDF5.jl/blob/master/ext/CodecLz4Ext/CodecLz4Ext.jl
https://github.com/cgohlke/imagecodecs/blob/master/imagecodecs/_lz4.pyx

