### PR TITLE
Fix LZ4 block size info

### DIFF
--- a/LZ4/src/H5Zlz4.c
+++ b/LZ4/src/H5Zlz4.c
@@ -74,7 +74,7 @@ static size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts,
 #define be64toht(x) ntohll(x)
 
 
-#define DEFAULT_BLOCK_SIZE 1<<30; /* 1GB. LZ4 needs blocks < 1.9GB. */
+#define DEFAULT_BLOCK_SIZE 1<<30; /* 1GiB. LZ4 needs blocks < 1.97GiB. */
 
 const H5Z_class2_t H5Z_LZ4[1] = {{
         H5Z_CLASS_T_VERS,       /* H5Z_class_t version */

--- a/docs/RegisteredFilterPlugins.md
+++ b/docs/RegisteredFilterPlugins.md
@@ -300,7 +300,7 @@ Number of `cd_values[]` parameters is one (`cd_nelmts = 1`).
 
 | `cd_values[]` | Description |
 |---|---|
-| `[0]` | Block size in bytes smaller than 1.9 GB. Default is 1 GB. (optional) |
+| `[0]` | Block size in bytes smaller than 1.9 GB. Default is 1 GiB (1,073,741,824 bytes). (optional) |
 
 `h5repack` example for the `--filter` option: `<objects list>:UD=32004,0,0`.
 


### PR DESCRIPTION
Fixes LZ4 block size information in the documentation and source code comments that was discussed in #173.