### PR TITLE
Use better cd_values[] in LZ4 example

### DIFF
--- a/LZ4/example/h5ex_d_lz4.c
+++ b/LZ4/example/h5ex_d_lz4.c
@@ -48,7 +48,7 @@ main (void)
     size_t          nelmts = 1;                /* number of elements in cd_values */
     unsigned int    flags;
     unsigned        filter_config;
-    const unsigned int    cd_values[1] = {3};     /* lz4 default is 3 */
+    const unsigned int    cd_values[1] = {CHUNK0 * CHUNK1 * sizeof(int)};  /* lz4 default is 1,073,741,824 bytes */
     unsigned int    values_out[1] = {99};
     int             wdata[DIM0][DIM1],          /* Write buffer */
                     rdata[DIM0][DIM1],          /* Read buffer */


### PR DESCRIPTION
The old value does not seem appropriate for the LZ4 filter as it is too small. Such small values will create much larger compressed chunks than the original chunk size.