### PR TITLE
Fix typo in cacheinit.cmake for h5pl testing

### DIFF
--- a/config/cmake/cacheinit.cmake
+++ b/config/cmake/cacheinit.cmake
@@ -17,7 +17,7 @@
 
 set (USE_SHARED_LIBS ON CACHE BOOL "Use Shared Libraries" FORCE)
 
-set (H5PL_BUILD_TESTING ON CACHE BOOL "Build h5blosc Unit Testing" FORCE)
+set (H5PL_BUILD_TESTING ON CACHE BOOL "Build h5pl Unit Testing" FORCE)
 set (H5PL_H5PL_BUILD_TESTING ON CACHE BOOL "Enable h5pl examples" FORCE)
 
 set (H5PL_BUILD_EXAMPLES ON CACHE BOOL "Build h5pl Examples" FORCE)


### PR DESCRIPTION
blosc -> pl
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes a typo in `cacheinit.cmake`, changing `h5blosc` to `h5pl` for unit testing configuration.
> 
>   - **Typo Fix**:
>     - Corrects typo in `cacheinit.cmake`, changing `h5blosc` to `h5pl` in the `H5PL_BUILD_TESTING` setting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5_plugins&utm_source=github&utm_medium=referral)<sup> for f8122007eda08ffbd0a03349ef3c46babb82c351. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->