### PR TITLE
Adds JPEG2000

### DIFF
--- a/docs/RegisteredFilterPlugins.md
+++ b/docs/RegisteredFilterPlugins.md
@@ -61,6 +61,7 @@ Upon receiving a request with the above information, HDF Group will register the
 |`32028`   |<a href="#sperr">SPERR</a>    |SPERR is a lossy scientific (floating-point) data compressor that produces one of the best rate-distortion curves|
 |`32029`   |<a href="#trpx">TERSE/PROLIX</a>    |A lossless and fast compression of the diffraction data|
 |`32030`   |<a href="#ffmpeg">FFMPEG</a>    |A lossy compression filter based on ffmpeg video library|
+|`32031`   |<a href="#jpeg2000">JPEG2000</a>    | A compression filter for lossy and lossless coding|
 
 > [!NOTE]
 > Please contact the maintainer of a filter plugin for help with the plugin or its filter in the HDF5 library.
@@ -871,3 +872,19 @@ License: Under MIT License
 
 ##### Contact
 Cai Lab at University of Michigan: https://www.cai-lab.org
+
+---
+
+### JPEG2000 <a name="jpeg2000"></a>
+
+#### Filter Description
+
+JPEG2000 is the Swiss Army knife of image codecs. It supports lossy and lossless coding, up to 16384 components, bit depth up to 38 bits/sample, terapixel images, resolution and quality scalability, progressive decoding and sub-frame latency, region-of-interest accessibility, non-iterative optimal rate control, discontinuous media such as optical flow data and stereo disparity maps.
+
+#### Plugin ID `32031` Information
+
+https://github.com/hmaarrfk/hdf5_jpeg2000/
+
+##### Contact
+Mark Harfouche
+mark dot harfouche at gmail dot com


### PR DESCRIPTION
Helpdesk ticket HELP-2950
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds JPEG2000 filter plugin with ID `32031` to `RegisteredFilterPlugins.md`, including description and contact information.
> 
>   - **Behavior**:
>     - Adds JPEG2000 filter plugin with ID `32031` to `RegisteredFilterPlugins.md`.
>     - Describes JPEG2000 as supporting lossy and lossless coding, up to 16384 components, and other advanced features.
>   - **Documentation**:
>     - Updates `RegisteredFilterPlugins.md` to include JPEG2000 filter description and contact information for Mark Harfouche.
>     - Provides GitHub link for JPEG2000 plugin: `https://github.com/hmaarrfk/hdf5_jpeg2000/`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5_plugins&utm_source=github&utm_medium=referral)<sup> for 8ac192799ef4fdce611aea696086fc1de3783305. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->