### PR TITLE
Change name in release files from hardcoded "master" to release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
     needs: log-the-inputs
     uses: ./.github/workflows/tarball.yml
     with:
-      use_tag: master
+      use_tag: ${{ needs.log-the-inputs.outputs.rel_tag }}
       use_environ: release
 
   call-workflow-ctest:


### PR DESCRIPTION
vvariable.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `use_tag` from hardcoded `master` to dynamic release tag in `release.yml`.
> 
>   - **Behavior**:
>     - Change `use_tag` from hardcoded `master` to dynamic `${{ needs.log-the-inputs.outputs.rel_tag }}` in `release.yml`.
>     - Affects `call-workflow-tarball` job, ensuring correct release tag is used.
>   - **Misc**:
>     - No other files or functionalities are affected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5_plugins&utm_source=github&utm_medium=referral)<sup> for 4d2b7fff9aa961d5185bc17d69d78ebc297967bd. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->