### PR TITLE
Temporarily skip a BITROUND test on ARM64 Windows

### DIFF
--- a/BITROUND/config/cmake/binex/example/CMakeLists.txt
+++ b/BITROUND/config/cmake/binex/example/CMakeLists.txt
@@ -111,6 +111,12 @@ if (H5PL_BUILD_TESTING)
       set_tests_properties (H5DUMP-${testname} PROPERTIES
           WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
           DEPENDS ${testname})
+      # This test currently fails on ARM64 Windows and needs more investigation
+      if ("H5DUMP-${testname}" MATCHES "H5DUMP-h5ex_d_granularbr" AND MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+        if (CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64|AARCH64" OR CMAKE_C_COMPILER_ARCHITECTURE_ID MATCHES "ARM64")
+          set_tests_properties (H5DUMP-${testname} PROPERTIES DISABLED TRUE)
+        endif ()
+      endif ()
       set (last_test "H5DUMP-${testname}")
     endif ()
   endmacro ()

--- a/BITROUND/example/CMakeLists.txt
+++ b/BITROUND/example/CMakeLists.txt
@@ -116,6 +116,12 @@ if (H5PL_BUILD_TESTING)
       set_tests_properties (H5DUMP-${testname} PROPERTIES
           WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
           DEPENDS ${testname})
+      # This test currently fails on ARM64 Windows and needs more investigation
+      if ("H5DUMP-${testname}" MATCHES "H5DUMP-h5ex_d_granularbr" AND MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+        if (CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64|AARCH64" OR CMAKE_C_COMPILER_ARCHITECTURE_ID MATCHES "ARM64")
+          set_tests_properties (H5DUMP-${testname} PROPERTIES DISABLED TRUE)
+        endif ()
+      endif ()
       set (last_test "H5DUMP-${testname}")
     endif ()
   endmacro ()

--- a/config/cmake/binex/example/CMakeLists.txt
+++ b/config/cmake/binex/example/CMakeLists.txt
@@ -202,6 +202,12 @@ if (H5PL_BUILD_TESTING)
       set_tests_properties (H5DUMP-${testname} PROPERTIES
           WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
           DEPENDS ${testname})
+      # This test currently fails on ARM64 Windows and needs more investigation
+      if ("H5DUMP-${testname}" MATCHES "H5DUMP-h5ex_d_granularbr" AND MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+        if (CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64|AARCH64" OR CMAKE_C_COMPILER_ARCHITECTURE_ID MATCHES "ARM64")
+          set_tests_properties (H5DUMP-${testname} PROPERTIES DISABLED TRUE)
+        endif ()
+      endif ()
       set (last_test "H5DUMP-${testname}")
     endif ()
   endmacro ()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Temporarily disable `H5DUMP-h5ex_d_granularbr` test on ARM64 Windows in three CMakeLists.txt files due to failures.
> 
>   - **Testing**:
>     - Temporarily disable `H5DUMP-h5ex_d_granularbr` test on ARM64 Windows in `BITROUND/config/cmake/binex/example/CMakeLists.txt`, `BITROUND/example/CMakeLists.txt`, and `config/cmake/binex/example/CMakeLists.txt`.
>     - Disabling condition: ARM64 architecture, Windows environment, and 64-bit pointer size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5_plugins&utm_source=github&utm_medium=referral)<sup> for 6c27e5d378e65619cea2c96b6c625c7e7eecdc9f. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->