### PR TITLE
Add extra path to HDF5_PLUGIN_PATH for Windows binary testing

### DIFF
--- a/config/cmake/binex/example/CMakeLists.txt
+++ b/config/cmake/binex/example/CMakeLists.txt
@@ -72,6 +72,7 @@ if (H5PL_BUILD_TESTING)
   # Unix/Mac: HDF5/share/HDFPLExamples/example -> ../../../lib/plugin
   if (WIN32)
     set (_plugin_path "${PROJECT_SOURCE_DIR}/../../lib/plugin")
+    set (_plugin_path "${_plugin_path}:${PROJECT_SOURCE_DIR}/../../plugin")
   else ()
     set (_plugin_path "${PROJECT_SOURCE_DIR}/../../../lib/plugin")
     set (_plugin_path "${_plugin_path}:${PROJECT_SOURCE_DIR}/../../../lib64/plugin")


### PR DESCRIPTION
Needed for ZFP testing currently as all plugins except for ZFP get installed under `ROOT\lib\plugin` on Windows, whereas ZFP goes under `ROOT\plugin`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds an extra path to `HDF5_PLUGIN_PATH` in `CMakeLists.txt` for Windows to support ZFP testing.
> 
>   - **Behavior**:
>     - Adds an extra path to `_plugin_path` for Windows in `CMakeLists.txt` to include `ROOT/plugin` for ZFP testing.
>     - Ensures both `ROOT/lib/plugin` and `ROOT/plugin` are checked for plugins on Windows.
>   - **Testing**:
>     - Affects `H5PL_BUILD_TESTING` section to ensure ZFP plugin is found during tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5_plugins&utm_source=github&utm_medium=referral)<sup> for 371bda7037a6cdf6b00ab29b144c8a2271206590. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->