### PR TITLE
Set draft to true for a release.

### DIFF
--- a/.github/workflows/release-files.yml
+++ b/.github/workflows/release-files.yml
@@ -175,6 +175,7 @@ jobs:
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:
           tag_name: "${{ inputs.use_tag }}"
+          draft: true
           prerelease: false
           files: |
               ${{ steps.get-file-base.outputs.FILE_BASE }}.tar.gz


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `draft: true` to the `Release tag` step in `release-files.yml`, making releases drafts initially.
> 
>   - **Behavior**:
>     - Adds `draft: true` to the `Release tag` step in `release-files.yml`, making releases drafts initially.
>     - Affects releases when `inputs.use_environ` is set to `release`.
>   - **Misc**:
>     - No changes to other steps or logic in the workflow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5_plugins&utm_source=github&utm_medium=referral)<sup> for b6486ccdaacbfd225eb917d8ad55bdbdc69341e3. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->