### PR TITLE
[ 2_1_0 ] Set draft to true for a release.

### DIFF
--- a/.github/workflows/release-files.yml
+++ b/.github/workflows/release-files.yml
@@ -175,6 +175,7 @@ jobs:
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:
           tag_name: "${{ inputs.use_tag }}"
+          draft: true
           prerelease: false
           files: |
               ${{ steps.get-file-base.outputs.FILE_BASE }}.tar.gz


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Sets `draft: true` for release creation in `release-files.yml`, marking releases as drafts initially.
> 
>   - **Behavior**:
>     - Sets `draft: true` for release creation in `release-files.yml`, marking releases as drafts initially.
>   - **Workflow**:
>     - Modifies `softprops/action-gh-release` step to include `draft: true` for the `Release tag` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5_plugins&utm_source=github&utm_medium=referral)<sup> for c3c9a68e87a32f686e284e9e406080e6b36f168b. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->