### PR TITLE
Fix plugin path separator on Windows

### DIFF
--- a/config/cmake/binex/example/CMakeLists.txt
+++ b/config/cmake/binex/example/CMakeLists.txt
@@ -72,7 +72,7 @@ if (H5PL_BUILD_TESTING)
   # Unix/Mac: HDF5/share/HDFPLExamples/example -> ../../../lib/plugin
   if (WIN32)
     set (_plugin_path "${PROJECT_SOURCE_DIR}/../../lib/plugin")
-    set (_plugin_path "${_plugin_path}:${PROJECT_SOURCE_DIR}/../../plugin")
+    set (_plugin_path "${_plugin_path}\;${PROJECT_SOURCE_DIR}/../../plugin")
   else ()
     set (_plugin_path "${PROJECT_SOURCE_DIR}/../../../lib/plugin")
     set (_plugin_path "${_plugin_path}:${PROJECT_SOURCE_DIR}/../../../lib64/plugin")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes Windows path separator for `_plugin_path` in `CMakeLists.txt` to ensure correct plugin path handling.
> 
>   - **Behavior**:
>     - Fixes path separator for `_plugin_path` in `CMakeLists.txt` on Windows from `:` to `;`.
>     - Ensures correct plugin path handling for Windows systems.
>   - **Misc**:
>     - No changes to Unix/Mac path handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5_plugins&utm_source=github&utm_medium=referral)<sup> for d6efca5bead0b8345a6ae2fe2e3728cfe583072a. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->