### PR TITLE
Fix filter callback buffer size for LZ4 read and BLOSC2 compress

### DIFF
--- a/BLOSC2/src/H5Zblosc2.c
+++ b/BLOSC2/src/H5Zblosc2.c
@@ -679,7 +679,7 @@ b2_decomp_out:
     if (status > 0) {
         free(*buf);
         *buf      = outbuf;
-        *buf_size = outbuf_size;
+        *buf_size = ((size_t)status > outbuf_size) ? (size_t)status : outbuf_size;
         return status; /* Size of compressed/decompressed data */
     }
 

--- a/LZ4/src/H5Zlz4.c
+++ b/LZ4/src/H5Zlz4.c
@@ -156,8 +156,9 @@ H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts, const unsigned int cd_value
             decompSize += blockSize;
         }
         free(*buf);
-        *buf   = outBuf;
-        outBuf = NULL;
+        *buf      = outBuf;
+        *buf_size = (size_t)origSize;
+        outBuf    = NULL;
         ret_value =
             (size_t)origSize; // should always work, as orig_size cannot be > 2GB (sizeof(size_t) < 4GB)
     }


### PR DESCRIPTION
HDF5 PR HDFGroup/hdf5#6184 added a stricter check that filters report `*buf_size` >= return value after running. The LZ4 plugin decompression path failed to update `*buf_size` after reallocating, and the BLOSC2 plugin compression path left it at the precomputed uncompressed-chunk size, which can be smaller than the compressed output for small or incompressible chunks.