### PR TITLE
Return correct buffer size after compression in blosc2 and lz4

### DIFF
--- a/BLOSC2/src/H5Zblosc2.c
+++ b/BLOSC2/src/H5Zblosc2.c
@@ -511,10 +511,12 @@ blosc2_filter_function(unsigned int flags, size_t cd_nelmts, const unsigned int 
             }
 
             bool needs_free;
-            if (b2nd_to_cframe(array, (uint8_t **)&outbuf, &status, &needs_free) < 0) {
+            int64_t outbuf_size_i64;
+            if (b2nd_to_cframe(array, (uint8_t **)&outbuf, &outbuf_size_i64, &needs_free) < 0) {
                 PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot convert B2ND array to buffer");
                 goto b2nd_comp_out;
             }
+            outbuf_size = (size_t)outbuf_size_i64;
 
 b2nd_comp_out:
             if (array)
@@ -539,11 +541,13 @@ b2nd_comp_out:
             }
 
             bool needs_free;
-            status = blosc2_schunk_to_buffer(schunk, (uint8_t **)&outbuf, &needs_free);
-            if (status < 0 || !needs_free) {
+            int64_t outbuf_size_i64;
+            outbuf_size_i64 = blosc2_schunk_to_buffer(schunk, (uint8_t **)&outbuf, &needs_free);
+            if (i64_outbuf_size < 0 || !needs_free) {
                 PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot convert super-chunk to buffer");
                 goto b2_comp_out;
             }
+            outbuf_size = (size_t)outbuf_size_i64;
 
 b2_comp_out:
             if (schunk)

--- a/BLOSC2/src/H5Zblosc2.c
+++ b/BLOSC2/src/H5Zblosc2.c
@@ -511,12 +511,12 @@ blosc2_filter_function(unsigned int flags, size_t cd_nelmts, const unsigned int 
             }
 
             bool    needs_free;
-            int64_t outbuf_size_i64;
-            if (b2nd_to_cframe(array, (uint8_t **)&outbuf, &outbuf_size_i64, &needs_free) < 0) {
+            if (b2nd_to_cframe(array, (uint8_t **)&outbuf, &status, &needs_free) < 0) {
                 PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot convert B2ND array to buffer");
                 goto b2nd_comp_out;
             }
-            outbuf_size = (size_t)outbuf_size_i64;
+            /* b2nd_to_cframe() returns the buffer size in the third paramter, status */
+            outbuf_size = (size_t)status;
 
 b2nd_comp_out:
             if (array)
@@ -541,13 +541,13 @@ b2nd_comp_out:
             }
 
             bool    needs_free;
-            int64_t outbuf_size_i64;
-            outbuf_size_i64 = blosc2_schunk_to_buffer(schunk, (uint8_t **)&outbuf, &needs_free);
-            if (outbuf_size_i64 < 0 || !needs_free) {
+            status = blosc2_schunk_to_buffer(schunk, (uint8_t **)&outbuf, &needs_free);
+            if (status < 0 || !needs_free) {
                 PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot convert super-chunk to buffer");
                 goto b2_comp_out;
             }
-            outbuf_size = (size_t)outbuf_size_i64;
+            /* blosc2_schunk_to_buffer() returns the buffer size, stored here in status */
+            outbuf_size = (size_t)status;
 
 b2_comp_out:
             if (schunk)

--- a/BLOSC2/src/H5Zblosc2.c
+++ b/BLOSC2/src/H5Zblosc2.c
@@ -510,7 +510,7 @@ blosc2_filter_function(unsigned int flags, size_t cd_nelmts, const unsigned int 
                 goto b2nd_comp_out;
             }
 
-            bool    needs_free;
+            bool needs_free;
             if (b2nd_to_cframe(array, (uint8_t **)&outbuf, &status, &needs_free) < 0) {
                 PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot convert B2ND array to buffer");
                 goto b2nd_comp_out;
@@ -540,7 +540,7 @@ b2nd_comp_out:
                 goto b2_comp_out;
             }
 
-            bool    needs_free;
+            bool needs_free;
             status = blosc2_schunk_to_buffer(schunk, (uint8_t **)&outbuf, &needs_free);
             if (status < 0 || !needs_free) {
                 PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot convert super-chunk to buffer");

--- a/BLOSC2/src/H5Zblosc2.c
+++ b/BLOSC2/src/H5Zblosc2.c
@@ -543,7 +543,7 @@ b2nd_comp_out:
             bool    needs_free;
             int64_t outbuf_size_i64;
             outbuf_size_i64 = blosc2_schunk_to_buffer(schunk, (uint8_t **)&outbuf, &needs_free);
-            if (i64_outbuf_size < 0 || !needs_free) {
+            if (outbuf_size_i64 < 0 || !needs_free) {
                 PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot convert super-chunk to buffer");
                 goto b2_comp_out;
             }

--- a/BLOSC2/src/H5Zblosc2.c
+++ b/BLOSC2/src/H5Zblosc2.c
@@ -510,7 +510,7 @@ blosc2_filter_function(unsigned int flags, size_t cd_nelmts, const unsigned int 
                 goto b2nd_comp_out;
             }
 
-            bool needs_free;
+            bool    needs_free;
             int64_t outbuf_size_i64;
             if (b2nd_to_cframe(array, (uint8_t **)&outbuf, &outbuf_size_i64, &needs_free) < 0) {
                 PUSH_ERR("blosc2_filter", H5E_CALLBACK, "Cannot convert B2ND array to buffer");
@@ -540,7 +540,7 @@ b2nd_comp_out:
                 goto b2_comp_out;
             }
 
-            bool needs_free;
+            bool    needs_free;
             int64_t outbuf_size_i64;
             outbuf_size_i64 = blosc2_schunk_to_buffer(schunk, (uint8_t **)&outbuf, &needs_free);
             if (i64_outbuf_size < 0 || !needs_free) {

--- a/LZ4/src/H5Zlz4.c
+++ b/LZ4/src/H5Zlz4.c
@@ -156,9 +156,9 @@ H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts, const unsigned int cd_value
             decompSize += blockSize;
         }
         free(*buf);
-        *buf   = outBuf;
+        *buf      = outBuf;
         *buf_size = (size_t)origSize;
-        outBuf = NULL;
+        outBuf    = NULL;
         ret_value =
             (size_t)origSize; // should always work, as orig_size cannot be > 2GB (sizeof(size_t) < 4GB)
     }

--- a/LZ4/src/H5Zlz4.c
+++ b/LZ4/src/H5Zlz4.c
@@ -157,6 +157,7 @@ H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts, const unsigned int cd_value
         }
         free(*buf);
         *buf   = outBuf;
+        *buf_size = (size_t)origSize;
         outBuf = NULL;
         ret_value =
             (size_t)origSize; // should always work, as orig_size cannot be > 2GB (sizeof(size_t) < 4GB)


### PR DESCRIPTION
Filters need to return the correct buffer size to avoid memory errors. This is now enforced in HDF5 develop, though not doing so could be a problem for any version of HDF5. I haven't tested this yet since, hopefully there are automated checks.