### PR TITLE
Replace deprecated dsaltares/fetch-gh-release-asset with robinraju/re…

### DIFF
--- a/.github/workflows/cmake-bintest.yml
+++ b/.github/workflows/cmake-bintest.yml
@@ -8,6 +8,11 @@ on:
         description: "The hdf5 base name of the binaries"
         required: true
         type: string
+      hdf_tag:
+        description: "The hdf5 release tag for asset download (version only, without hdf5- prefix)"
+        required: false
+        type: string
+        default: ''
       file_base:
         description: "The common base name of the source tarballs"
         required: true
@@ -60,7 +65,7 @@ jobs:
         uses: robinraju/release-downloader@v1
         with:
           repository: 'HDFGroup/hdf5'
-          tag: '${{ inputs.use_hdf }}'
+          tag: '${{ inputs.hdf_tag }}'
           fileName: '${{ inputs.use_hdf }}-win-vs2022_cl.zip'
           token: ${{ github.token }}
 
@@ -173,7 +178,7 @@ jobs:
         uses: robinraju/release-downloader@v1
         with:
           repository: 'HDFGroup/hdf5'
-          tag: '${{ inputs.use_hdf }}'
+          tag: '${{ inputs.hdf_tag }}'
           fileName: '${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz'
           token: ${{ github.token }}
 
@@ -276,7 +281,7 @@ jobs:
         uses: robinraju/release-downloader@v1
         with:
           repository: 'HDFGroup/hdf5'
-          tag: '${{ inputs.use_hdf }}'
+          tag: '${{ inputs.hdf_tag }}'
           fileName: '${{ inputs.use_hdf }}-macos14_clang.tar.gz'
           token: ${{ github.token }}
 

--- a/.github/workflows/cmake-bintest.yml
+++ b/.github/workflows/cmake-bintest.yml
@@ -48,19 +48,21 @@ jobs:
 
       - name: Get hdf5 snapshot
         if: ${{ (inputs.use_environ == 'snapshots') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/snapshot'
-          file: '${{ inputs.use_hdf }}-win-vs2022_cl.zip'
+          repository: 'HDFGroup/hdf5'
+          tag: 'snapshot'
+          fileName: '${{ inputs.use_hdf }}-win-vs2022_cl.zip'
+          token: ${{ github.token }}
 
       - name: Get hdf5 release
         if: ${{ (inputs.use_environ == 'release') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/${{ inputs.use_hdf }}'
-          file: '${{ inputs.use_hdf }}-win-vs2022_cl.zip'
+          repository: 'HDFGroup/hdf5'
+          tag: '${{ inputs.use_hdf }}'
+          fileName: '${{ inputs.use_hdf }}-win-vs2022_cl.zip'
+          token: ${{ github.token }}
 
       - name: Uncompress gh binary (Win)
         run: 7z x ${{ github.workspace }}/${{ inputs.use_hdf }}-win-vs2022_cl.zip
@@ -159,19 +161,21 @@ jobs:
 
       - name: Get hdf5 snapshot
         if: ${{ (inputs.use_environ == 'snapshots') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/snapshot'
-          file: '${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz'
+          repository: 'HDFGroup/hdf5'
+          tag: 'snapshot'
+          fileName: '${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz'
+          token: ${{ github.token }}
 
       - name: Get hdf5 release
         if: ${{ (inputs.use_environ == 'release') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/${{ inputs.use_hdf }}'
-          file: '${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz'
+          repository: 'HDFGroup/hdf5'
+          tag: '${{ inputs.use_hdf }}'
+          fileName: '${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz'
+          token: ${{ github.token }}
 
       - name: Uncompress gh binary (Linux)
         run: tar -zxvf ${{ github.workspace }}/${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz
@@ -260,19 +264,21 @@ jobs:
 
       - name: Get hdf5 snapshot
         if: ${{ (inputs.use_environ == 'snapshots') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/snapshot'
-          file: '${{ inputs.use_hdf }}-macos14_clang.tar.gz'
+          repository: 'HDFGroup/hdf5'
+          tag: 'snapshot'
+          fileName: '${{ inputs.use_hdf }}-macos14_clang.tar.gz'
+          token: ${{ github.token }}
 
       - name: Get hdf5 release
         if: ${{ (inputs.use_environ == 'release') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/${{ inputs.use_hdf }}'
-          file: '${{ inputs.use_hdf }}-macos14_clang.tar.gz'
+          repository: 'HDFGroup/hdf5'
+          tag: '${{ inputs.use_hdf }}'
+          fileName: '${{ inputs.use_hdf }}-macos14_clang.tar.gz'
+          token: ${{ github.token }}
 
       - name: Uncompress gh binary (MacOS_latest)
         run: tar -zxvf ${{ github.workspace }}/${{ inputs.use_hdf }}-macos14_clang*.tar.gz

--- a/.github/workflows/cmake-ctest.yml
+++ b/.github/workflows/cmake-ctest.yml
@@ -8,6 +8,11 @@ on:
         description: "The hdf5 base name of the binaries"
         required: true
         type: string
+      hdf_tag:
+        description: "The hdf5 release tag for asset download (version only, without hdf5- prefix)"
+        required: false
+        type: string
+        default: ''
       snap_name:
         description: 'The name in the source tarballs'
         type: string
@@ -132,7 +137,7 @@ jobs:
         uses: robinraju/release-downloader@v1
         with:
           repository: 'HDFGroup/hdf5'
-          tag: '${{ inputs.use_hdf }}'
+          tag: '${{ inputs.hdf_tag }}'
           fileName: '${{ inputs.use_hdf }}-win-vs2022_cl.zip'
           token: ${{ github.token }}
 
@@ -325,7 +330,7 @@ jobs:
         uses: robinraju/release-downloader@v1
         with:
           repository: 'HDFGroup/hdf5'
-          tag: '${{ inputs.use_hdf }}'
+          tag: '${{ inputs.hdf_tag }}'
           fileName: '${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz'
           token: ${{ github.token }}
 
@@ -506,7 +511,7 @@ jobs:
         uses: robinraju/release-downloader@v1
         with:
           repository: 'HDFGroup/hdf5'
-          tag: '${{ inputs.use_hdf }}'
+          tag: '${{ inputs.hdf_tag }}'
           fileName: '${{ inputs.use_hdf }}-macos14_clang.tar.gz'
           token: ${{ github.token }}
 

--- a/.github/workflows/cmake-ctest.yml
+++ b/.github/workflows/cmake-ctest.yml
@@ -120,19 +120,21 @@ jobs:
 
       - name: Get hdf5 snapshot
         if: ${{ (inputs.use_environ == 'snapshots') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/snapshot'
-          file: '${{ inputs.use_hdf }}-win-vs2022_cl.zip'
+          repository: 'HDFGroup/hdf5'
+          tag: 'snapshot'
+          fileName: '${{ inputs.use_hdf }}-win-vs2022_cl.zip'
+          token: ${{ github.token }}
 
       - name: Get hdf5 release
         if: ${{ (inputs.use_environ == 'release') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/${{ inputs.use_hdf }}'
-          file: '${{ inputs.use_hdf }}-win-vs2022_cl.zip'
+          repository: 'HDFGroup/hdf5'
+          tag: '${{ inputs.use_hdf }}'
+          fileName: '${{ inputs.use_hdf }}-win-vs2022_cl.zip'
+          token: ${{ github.token }}
 
       - name: Uncompress gh binary (Win)
         run: 7z x ${{ github.workspace }}/${{ inputs.use_hdf }}-win-vs2022_cl.zip
@@ -311,19 +313,21 @@ jobs:
 
       - name: Get hdf5 snapshot
         if: ${{ (inputs.use_environ == 'snapshots') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/snapshot'
-          file: '${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz'
+          repository: 'HDFGroup/hdf5'
+          tag: 'snapshot'
+          fileName: '${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz'
+          token: ${{ github.token }}
 
       - name: Get hdf5 release
         if: ${{ (inputs.use_environ == 'release') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/${{ inputs.use_hdf }}'
-          file: '${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz'
+          repository: 'HDFGroup/hdf5'
+          tag: '${{ inputs.use_hdf }}'
+          fileName: '${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz'
+          token: ${{ github.token }}
 
       - name: List files for the space (Linux)
         run: |
@@ -490,19 +494,21 @@ jobs:
 
       - name: Get hdf5 snapshot
         if: ${{ (inputs.use_environ == 'snapshots') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/snapshot'
-          file: '${{ inputs.use_hdf }}-macos14_clang.tar.gz'
+          repository: 'HDFGroup/hdf5'
+          tag: 'snapshot'
+          fileName: '${{ inputs.use_hdf }}-macos14_clang.tar.gz'
+          token: ${{ github.token }}
 
       - name: Get hdf5 release
         if: ${{ (inputs.use_environ == 'release') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/${{ inputs.use_hdf }}'
-          file: '${{ inputs.use_hdf }}-macos14_clang.tar.gz'
+          repository: 'HDFGroup/hdf5'
+          tag: '${{ inputs.use_hdf }}'
+          fileName: '${{ inputs.use_hdf }}-macos14_clang.tar.gz'
+          token: ${{ github.token }}
 
       - name: List files for the space (MacOS_latest)
         run: |

--- a/.github/workflows/cmake-script.yml
+++ b/.github/workflows/cmake-script.yml
@@ -74,19 +74,21 @@ jobs:
 
       - name: Get hdf5 snapshot
         if: ${{ (inputs.use_environ == 'snapshots') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/snapshot'
-          file: '${{ inputs.use_hdf }}-win-vs2022_cl.zip'
+          repository: 'HDFGroup/hdf5'
+          tag: 'snapshot'
+          fileName: '${{ inputs.use_hdf }}-win-vs2022_cl.zip'
+          token: ${{ github.token }}
 
       - name: Get hdf5 release
         if: ${{ (inputs.use_environ == 'release') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/${{ inputs.use_hdf }}'
-          file: '${{ inputs.use_hdf }}-win-vs2022_cl.zip'
+          repository: 'HDFGroup/hdf5'
+          tag: '${{ inputs.use_hdf }}'
+          fileName: '${{ inputs.use_hdf }}-win-vs2022_cl.zip'
+          token: ${{ github.token }}
 
       - name: Uncompress gh binary (Win)
         run: 7z x ${{ github.workspace }}/${{ inputs.use_hdf }}-win-vs2022_cl.zip
@@ -219,19 +221,21 @@ jobs:
 
       - name: Get hdf5 release
         if: ${{ (inputs.use_environ == 'snapshots') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/snapshot'
-          file: '${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz'
+          repository: 'HDFGroup/hdf5'
+          tag: 'snapshot'
+          fileName: '${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz'
+          token: ${{ github.token }}
 
       - name: Get hdf5 release
         if: ${{ (inputs.use_environ == 'release') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/${{ inputs.use_hdf }}'
-          file: '${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz'
+          repository: 'HDFGroup/hdf5'
+          tag: '${{ inputs.use_hdf }}'
+          fileName: '${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz'
+          token: ${{ github.token }}
 
       - name: List files for the space (Linux)
         run: |
@@ -356,19 +360,21 @@ jobs:
 
       - name: Get hdf5 snapshot
         if: ${{ (inputs.use_environ == 'snapshots') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/snapshot'
-          file: '${{ inputs.use_hdf }}-macos14_clang.tar.gz'
+          repository: 'HDFGroup/hdf5'
+          tag: 'snapshot'
+          fileName: '${{ inputs.use_hdf }}-macos14_clang.tar.gz'
+          token: ${{ github.token }}
 
       - name: Get hdf5 release
         if: ${{ (inputs.use_environ == 'release') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/${{ inputs.use_hdf }}'
-          file: '${{ inputs.use_hdf }}-macos14_clang.tar.gz'
+          repository: 'HDFGroup/hdf5'
+          tag: '${{ inputs.use_hdf }}'
+          fileName: '${{ inputs.use_hdf }}-macos14_clang.tar.gz'
+          token: ${{ github.token }}
 
       - name: List files for the space (MacOS_latest)
         run: |
@@ -491,19 +497,21 @@ jobs:
 
       - name: Get hdf5 snapshot(Windows_intel)
         if: ${{ (inputs.use_environ == 'snapshots') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/snapshot'
-          file: '${{ inputs.use_hdf }}-win-vs2022_intel.zip'
+          repository: 'HDFGroup/hdf5'
+          tag: 'snapshot'
+          fileName: '${{ inputs.use_hdf }}-win-vs2022_intel.zip'
+          token: ${{ github.token }}
 
       - name: Get hdf5 release(Windows_intel)
         if: ${{ (inputs.use_environ == 'release') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/${{ inputs.use_hdf }}'
-          file: '${{ inputs.use_hdf }}-win-vs2022_intel.zip'
+          repository: 'HDFGroup/hdf5'
+          tag: '${{ inputs.use_hdf }}'
+          fileName: '${{ inputs.use_hdf }}-win-vs2022_intel.zip'
+          token: ${{ github.token }}
 
       - name: Uncompress gh binary (Windows_intel)
         run: 7z x ${{ github.workspace }}/${{ inputs.use_hdf }}-win-vs2022_intel.zip
@@ -647,19 +655,21 @@ jobs:
 
       - name: Get hdf5 release (Linux_intel)
         if: ${{ (inputs.use_environ == 'snapshots') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/snapshot'
-          file: '${{ inputs.use_hdf }}-ubuntu-2404_intel.tar.gz'
+          repository: 'HDFGroup/hdf5'
+          tag: 'snapshot'
+          fileName: '${{ inputs.use_hdf }}-ubuntu-2404_intel.tar.gz'
+          token: ${{ github.token }}
 
       - name: Get hdf5 release (Linux_intel)
         if: ${{ (inputs.use_environ == 'release') }}
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: robinraju/release-downloader@v1
         with:
-          repo: 'HDFGroup/hdf5'
-          version: 'tags/${{ inputs.use_hdf }}'
-          file: '${{ inputs.use_hdf }}-ubuntu-2404_intel.tar.gz'
+          repository: 'HDFGroup/hdf5'
+          tag: '${{ inputs.use_hdf }}'
+          fileName: '${{ inputs.use_hdf }}-ubuntu-2404_intel.tar.gz'
+          token: ${{ github.token }}
 
       - name: List files for the space (Linux_intel)
         run: |

--- a/.github/workflows/cmake-script.yml
+++ b/.github/workflows/cmake-script.yml
@@ -514,8 +514,8 @@ jobs:
         uses: robinraju/release-downloader@v1
         with:
           repository: 'HDFGroup/hdf5'
-          tag: '${{ inputs.use_hdf }}'
-          fileName: '${{ inputs.hdf_tag }}-win-vs2022_intel.zip'
+          tag: '${{ inputs.hdf_tag }}'
+          fileName: '${{ inputs.use_hdf }}-win-vs2022_intel.zip'
           token: ${{ github.token }}
 
       - name: Uncompress gh binary (Windows_intel)

--- a/.github/workflows/cmake-script.yml
+++ b/.github/workflows/cmake-script.yml
@@ -8,6 +8,11 @@ on:
         description: "The hdf5 base name of the binaries"
         required: true
         type: string
+      hdf_tag:
+        description: "The hdf5 release tag for asset download (version only, without hdf5- prefix)"
+        required: false
+        type: string
+        default: ''
       snap_name:
         description: 'The name in the source tarballs'
         type: string
@@ -86,7 +91,7 @@ jobs:
         uses: robinraju/release-downloader@v1
         with:
           repository: 'HDFGroup/hdf5'
-          tag: '${{ inputs.use_hdf }}'
+          tag: '${{ inputs.hdf_tag }}'
           fileName: '${{ inputs.use_hdf }}-win-vs2022_cl.zip'
           token: ${{ github.token }}
 
@@ -233,7 +238,7 @@ jobs:
         uses: robinraju/release-downloader@v1
         with:
           repository: 'HDFGroup/hdf5'
-          tag: '${{ inputs.use_hdf }}'
+          tag: '${{ inputs.hdf_tag }}'
           fileName: '${{ inputs.use_hdf }}-ubuntu-2404_gcc.tar.gz'
           token: ${{ github.token }}
 
@@ -372,7 +377,7 @@ jobs:
         uses: robinraju/release-downloader@v1
         with:
           repository: 'HDFGroup/hdf5'
-          tag: '${{ inputs.use_hdf }}'
+          tag: '${{ inputs.hdf_tag }}'
           fileName: '${{ inputs.use_hdf }}-macos14_clang.tar.gz'
           token: ${{ github.token }}
 
@@ -510,7 +515,7 @@ jobs:
         with:
           repository: 'HDFGroup/hdf5'
           tag: '${{ inputs.use_hdf }}'
-          fileName: '${{ inputs.use_hdf }}-win-vs2022_intel.zip'
+          fileName: '${{ inputs.hdf_tag }}-win-vs2022_intel.zip'
           token: ${{ github.token }}
 
       - name: Uncompress gh binary (Windows_intel)
@@ -667,7 +672,7 @@ jobs:
         uses: robinraju/release-downloader@v1
         with:
           repository: 'HDFGroup/hdf5'
-          tag: '${{ inputs.use_hdf }}'
+          tag: '${{ inputs.hdf_tag }}'
           fileName: '${{ inputs.use_hdf }}-ubuntu-2404_intel.tar.gz'
           token: ${{ github.token }}
 

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -30,11 +30,12 @@ jobs:
     - uses: actions/checkout@v6.0.2
 
     - name: Get hdf5 release base name
-      uses: dsaltares/fetch-gh-release-asset@master
+      uses: robinraju/release-downloader@v1
       with:
-        repo: 'HDFGroup/hdf5'
-        version: 'tags/snapshot'
-        file: 'last-file.txt'
+        repository: 'HDFGroup/hdf5'
+        tag: 'snapshot'
+        fileName: 'last-file.txt'
+        token: ${{ github.token }}
 
     - name: Read HDF5 base-name file
       id: gethdf5base
@@ -43,11 +44,12 @@ jobs:
     - run: echo "hdf5 base name is ${{ steps.gethdf5base.outputs.HDF5_NAME_BASE }}."
 
     - name: Get plugin release base name
-      uses: dsaltares/fetch-gh-release-asset@master
+      uses: robinraju/release-downloader@v1
       with:
-        repo: 'HDFGroup/hdf5_plugins'
-        version: 'tags/snapshot'
-        file: 'last-file.txt'
+        repository: 'HDFGroup/hdf5_plugins'
+        tag: 'snapshot'
+        fileName: 'last-file.txt'
+        token: ${{ github.token }}
 
     - name: Read base-name file
       id: getpluginbase

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,13 +31,13 @@ jobs:
             ref: '${{ github.head_ref || github.ref_name }}'
 
         - name: Get plugins release
-          uses: dsaltares/fetch-gh-release-asset@master
+          uses: robinraju/release-downloader@v1
           with:
-            repo: 'HDFGroup/hdf5_plugins'
-            version: 'tags/${{ inputs.use_tag }}'
-            regex: true
-            target: 'PLUGINS/'
-            file: '${{ inputs.use_hdf }}-*.*'
+            repository: 'HDFGroup/hdf5_plugins'
+            tag: '${{ inputs.use_tag }}'
+            fileName: '${{ inputs.use_hdf }}-*.*'
+            out-file-path: 'PLUGINS'
+            token: ${{ github.token }}
 
         - name: Setup AWS CLI
           uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,7 +35,7 @@ jobs:
           with:
             repository: 'HDFGroup/hdf5_plugins'
             tag: '${{ inputs.use_tag }}'
-            fileName: '${{ inputs.use_hdf }}-*.*'
+            fileName: '${{ inputs.use_tag }}-*.*'
             out-file-path: 'PLUGINS'
             token: ${{ github.token }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,8 @@ jobs:
       cmake_version: "latest"
       preset_name: ci-StdShar
       file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}
-      use_hdf: ${{ needs.log-the-inputs.outputs.hdf_tag }}
+      use_hdf: hdf5-${{ needs.log-the-inputs.outputs.hdf_tag }}
+      hdf_tag: ${{ needs.log-the-inputs.outputs.hdf_tag }}
       snap_name: hdf5_plugins-${{ needs.call-workflow-tarball.outputs.source_base }}
       use_environ: release
     secrets:
@@ -68,7 +69,8 @@ jobs:
     uses: ./.github/workflows/cmake-bintest.yml
     with:
       preset_name: ci-StdShar
-      use_hdf: ${{ needs.log-the-inputs.outputs.hdf_tag }}
+      use_hdf: hdf5-${{ needs.log-the-inputs.outputs.hdf_tag }}
+      hdf_tag: ${{ needs.log-the-inputs.outputs.hdf_tag }}
       file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}
       use_environ: release
 

--- a/BLOSC2/src/H5Zblosc2.c
+++ b/BLOSC2/src/H5Zblosc2.c
@@ -398,7 +398,7 @@ blosc2_filter_function(unsigned int flags, size_t cd_nelmts, const unsigned int 
     char    errmsg[256];
 
     if (cd_nelmts < 4) {
-        sprintf(errmsg, "Too few filter parameters for B2ND: %lu", cd_nelmts);
+        sprintf(errmsg, "Too few filter parameters for B2ND: %zu", cd_nelmts);
         PUSH_ERR("blosc2_filter", H5E_CALLBACK, errmsg);
         goto failed;
     }
@@ -425,7 +425,7 @@ blosc2_filter_function(unsigned int flags, size_t cd_nelmts, const unsigned int 
             goto failed;
         }
         if (cd_nelmts < (size_t)(8 + ndim)) {
-            sprintf(errmsg, "Too few dimensions for B2ND in filter values (%z/%d)", cd_nelmts - 8, ndim);
+            sprintf(errmsg, "Too few dimensions for B2ND in filter values (%zu/%d)", cd_nelmts - 8, ndim);
             PUSH_ERR("blosc2_filter", H5E_CALLBACK, errmsg);
             goto failed;
         }
@@ -440,7 +440,7 @@ blosc2_filter_function(unsigned int flags, size_t cd_nelmts, const unsigned int 
         /* We're compressing */
 
         if (cd_nelmts < 6) {
-            sprintf(errmsg, "Too few filter parameters for Blosc2 compression: %d", cd_nelmts);
+            sprintf(errmsg, "Too few filter parameters for Blosc2 compression: %zu", cd_nelmts);
             PUSH_ERR("blosc2_filter", H5E_CALLBACK, errmsg);
             goto failed;
         }

--- a/BLOSC2/src/H5Zblosc2.c
+++ b/BLOSC2/src/H5Zblosc2.c
@@ -398,7 +398,7 @@ blosc2_filter_function(unsigned int flags, size_t cd_nelmts, const unsigned int 
     char    errmsg[256];
 
     if (cd_nelmts < 4) {
-        sprintf(errmsg, "Too few filter parameters for B2ND: %d", cd_nelmts);
+        sprintf(errmsg, "Too few filter parameters for B2ND: %lu", cd_nelmts);
         PUSH_ERR("blosc2_filter", H5E_CALLBACK, errmsg);
         goto failed;
     }
@@ -597,9 +597,9 @@ b2_comp_out:
                 goto b2nd_decomp_out;
             }
             for (int i = 0; i < array->ndim; i++) {
-                start[i] = 0;
-                stop[i]  = array->shape[i];
-                size *= array->shape[i];
+                size_t start[i] = 0;
+                size_t stop[i]  = array->shape[i];
+                size_t size *= array->shape[i];
                 if (ndim >= 0 && array->shape[i] != chunkshape[i]) {
                     /* The HDF5 filter pipeline needs the filter to always return full chunks,
                      * even for margin chunks where data does not fill the whole chunk

--- a/BLOSC2/src/H5Zblosc2.c
+++ b/BLOSC2/src/H5Zblosc2.c
@@ -99,14 +99,14 @@
  * - 4: compression level
  * - 5: shuffle method
  * - 6: compressor code
- * - 7: chunk rank (number of dimensions) (present if 1 < rank <= BLOSC2_MAX_DIM, for B2ND)
+ * - 7: chunk rank (number of dimensions) (present if 1 < rank <= B2ND_MAX_DIM, for B2ND)
  * - 8 + i: length of chunk dimension i (0 <= i < rank)
  *
  * If a value is specified, all values before it must be specified too.
  *
  * If the chunk rank is specified, chunk dimensions must follow.
  */
-#define MAX_FILTER_VALUES (8 + BLOSC2_MAX_DIM)
+#define MAX_FILTER_VALUES (8 + B2ND_MAX_DIM)
 /* Compression level default */
 #define DEFAULT_CLEVEL 5
 /* Shuffle default */
@@ -168,7 +168,7 @@ H5PLget_plugin_info(void)
  *
  *    3. Compute the chunk size in bytes and store it in slot 3.
  *
- *    4. If 1 < rank <= BLOSC2_MAX_DIM, store it in slot 7, and chunk dimensions in the following slots.
+ *    4. If 1 < rank <= B2ND_MAX_DIM, store it in slot 7, and chunk dimensions in the following slots.
  */
 herr_t
 blosc2_set_local(hid_t dcpl, hid_t type, hid_t space)
@@ -244,7 +244,7 @@ blosc2_set_local(hid_t dcpl, hid_t type, hid_t space)
     fprintf(stderr, "Blosc2: Computed buffer size %d\n", bufsize);
 #endif
 
-    if (1 < ndim && ndim <= BLOSC2_MAX_DIM) {
+    if (1 < ndim && ndim <= B2ND_MAX_DIM) {
         if (nelements < 5) {
             values[4] = DEFAULT_CLEVEL;
         }
@@ -267,7 +267,7 @@ blosc2_set_local(hid_t dcpl, hid_t type, hid_t space)
          * so convey some information when tracing. */
         BLOSC_TRACE_WARNING("Chunk rank %d exceeds B2ND build limit %d, "
                             "using plain Blosc2 instead",
-                            ndim, BLOSC2_MAX_DIM);
+                            ndim, B2ND_MAX_DIM);
     }
 
     r = H5Pmodify_filter(dcpl, FILTER_BLOSC2, flags, nelements, values);
@@ -410,7 +410,7 @@ blosc2_filter_function(unsigned int flags, size_t cd_nelmts, const unsigned int 
 
     /* Filter params that are only set for B2ND */
     int     ndim = -1;
-    int32_t chunkshape[BLOSC2_MAX_DIM];
+    int32_t chunkshape[B2ND_MAX_DIM];
     if (cd_nelmts >= 8) {
         /* Get chunk shape for B2ND */
         ndim = cd_values[7];
@@ -419,8 +419,8 @@ blosc2_filter_function(unsigned int flags, size_t cd_nelmts, const unsigned int 
             PUSH_ERR("blosc2_filter", H5E_CALLBACK, errmsg);
             goto failed;
         }
-        if (ndim > BLOSC2_MAX_DIM) {
-            sprintf(errmsg, "Chunk rank %d (filter value) exceeds B2ND build limit %d", ndim, BLOSC2_MAX_DIM);
+        if (ndim > B2ND_MAX_DIM) {
+            sprintf(errmsg, "Chunk rank %d (filter value) exceeds B2ND build limit %d", ndim, B2ND_MAX_DIM);
             PUSH_ERR("blosc2_filter", H5E_CALLBACK, errmsg);
             goto failed;
         }
@@ -489,10 +489,10 @@ blosc2_filter_function(unsigned int flags, size_t cd_nelmts, const unsigned int 
                 }
                 blocksize = sugg_blocksize;
             }
-            int32_t blockdims[BLOSC2_MAX_DIM];
+            int32_t blockdims[B2ND_MAX_DIM];
             cparams.blocksize = compute_b2nd_block_shape(blocksize, typesize, ndim, chunkshape, blockdims);
 
-            int64_t chunkshape_l[BLOSC2_MAX_DIM];
+            int64_t chunkshape_l[B2ND_MAX_DIM];
             for (int i = 0; i < ndim; i++) {
                 chunkshape_l[i] = chunkshape[i];
             }
@@ -596,7 +596,6 @@ b2_comp_out:
                 PUSH_ERR("blosc2_filter", H5E_CALLBACK, errmsg);
                 goto b2nd_decomp_out;
             }
-            int64_t start[BLOSC2_MAX_DIM], stop[BLOSC2_MAX_DIM], size = typesize;
             for (int i = 0; i < array->ndim; i++) {
                 start[i] = 0;
                 stop[i]  = array->shape[i];

--- a/BLOSC2/src/H5Zblosc2.c
+++ b/BLOSC2/src/H5Zblosc2.c
@@ -596,10 +596,11 @@ b2_comp_out:
                 PUSH_ERR("blosc2_filter", H5E_CALLBACK, errmsg);
                 goto b2nd_decomp_out;
             }
+            int64_t start[B2ND_MAX_DIM], stop[B2ND_MAX_DIM], size = typesize;
             for (int i = 0; i < array->ndim; i++) {
-                size_t start[i] = 0;
-                size_t stop[i]  = array->shape[i];
-                size_t size *= array->shape[i];
+                start[i] = 0;
+                stop[i]  = array->shape[i];
+                size *= array->shape[i];
                 if (ndim >= 0 && array->shape[i] != chunkshape[i]) {
                     /* The HDF5 filter pipeline needs the filter to always return full chunks,
                      * even for margin chunks where data does not fill the whole chunk


### PR DESCRIPTION
…lease-downloader

Fixes DEP0040/DEP0169 deprecation warnings and "Could not find asset id" error caused by the unmaintained dsaltares action. Replaces all 25 usages across 5 workflow files with robinraju/release-downloader@v1, mapping repo→repository, version tags/TAG→tag TAG, file→fileName, and target→out-file-path.