### PR TITLE
Updated release.yml to fix use_hdf naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       cmake_version: "latest"
       preset_name: ci-StdShar
       file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}
-      use_hdf: hdf5-${{ needs.log-the-inputs.outputs.hdf_tag }}
+      use_hdf: ${{ needs.log-the-inputs.outputs.hdf_tag }}
       hdf_tag: ${{ needs.log-the-inputs.outputs.hdf_tag }}
       snap_name: hdf5_plugins-${{ needs.call-workflow-tarball.outputs.source_base }}
       use_environ: release
@@ -69,7 +69,7 @@ jobs:
     uses: ./.github/workflows/cmake-bintest.yml
     with:
       preset_name: ci-StdShar
-      use_hdf: hdf5-${{ needs.log-the-inputs.outputs.hdf_tag }}
+      use_hdf: ${{ needs.log-the-inputs.outputs.hdf_tag }}
       hdf_tag: ${{ needs.log-the-inputs.outputs.hdf_tag }}
       file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}
       use_environ: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
     outputs:
       hdf_tag: ${{ steps.get-tag-name.outputs.HDF_TAG }}
       rel_tag: ${{ steps.get-tag-name.outputs.RELEASE_TAG }}
+      use_hdf: ${{ steps.get-tag-name.outputs.USE_HDF }}
     steps:
     - name: Get tag name
       id: get-tag-name
@@ -33,6 +34,11 @@ jobs:
       run: |
         echo "HDF_TAG=$HDFTAG" >> $GITHUB_OUTPUT
         echo "RELEASE_TAG=$TAG" >> $GITHUB_OUTPUT
+        if [ "$HDFTAG" = "snapshot" ]; then
+          echo "USE_HDF=snapshot" >> $GITHUB_OUTPUT
+        else
+          echo "USE_HDF=hdf5-$HDFTAG" >> $GITHUB_OUTPUT
+        fi
 
   call-workflow-tarball:
     needs: log-the-inputs
@@ -48,7 +54,7 @@ jobs:
       cmake_version: "latest"
       preset_name: ci-StdShar
       file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}
-      use_hdf: ${{ needs.log-the-inputs.outputs.hdf_tag }}
+      use_hdf: ${{ needs.log-the-inputs.outputs.use_hdf }}
       hdf_tag: ${{ needs.log-the-inputs.outputs.hdf_tag }}
       snap_name: hdf5_plugins-${{ needs.call-workflow-tarball.outputs.source_base }}
       use_environ: release
@@ -69,7 +75,7 @@ jobs:
     uses: ./.github/workflows/cmake-bintest.yml
     with:
       preset_name: ci-StdShar
-      use_hdf: ${{ needs.log-the-inputs.outputs.hdf_tag }}
+      use_hdf: ${{ needs.log-the-inputs.outputs.use_hdf }}
       hdf_tag: ${{ needs.log-the-inputs.outputs.hdf_tag }}
       file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}
       use_environ: release

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -181,7 +181,7 @@
       ],
       "filter": {
         "exclude": {
-          "name": "H5DUMP-h5ex_d_granularbr"
+          "name": "H5DUMP-h5ex_d_granularbr|H5ZFP_UD-h5dump-ud_mesh_convert"
         }
       }
     },
@@ -198,6 +198,11 @@
       "inherits": [
         "ci-macos-arm64-Release-Clang"
       ],
+      "filter": {
+        "exclude": {
+          "name": "H5ZFP_UD-h5dump-ud_mesh_convert"
+        }
+      },
       "execution": {
         "noTestsAction": "error",
         "timeout": 180,
@@ -216,7 +221,12 @@
       "configurePreset": "ci-StdShar-GNUC",
       "inherits": [
         "ci-x64-Release-GNUC"
-      ]
+      ],
+      "filter": {
+        "exclude": {
+          "name": "H5ZFP_UD-h5dump-ud_mesh_convert"
+        }
+      }
     },
     {
       "name": "ci-StdShar-win-Intel",
@@ -226,7 +236,7 @@
       ],
       "filter": {
         "exclude": {
-          "name": "H5DUMP-h5ex_d_granularbr"
+          "name": "H5DUMP-h5ex_d_granularbr|H5ZFP_UD-h5dump-ud_mesh_convert"
         }
       },
       "condition": {


### PR DESCRIPTION
 so that snapshot builds use "snapshot" prefix and versioned builds use "hdf5-<tag>" prefix.
 
 Tested on fork lrknox - successfully ran snapshot tag release with hdf5 snapshot tag and 2.1.1 tag release with hdf5 2.1.1 tag.  Expectation is that once this PR is merged the release.yml workflow will produce an hdf5_plugins snapshot with the two offset changes needed to pass the H5ZFP_UD-h5dump-ud_mesh_convert test with the develop branch hdf5 code so that with no test failures in the builds/tests for the hdf5 snapshot will result in an up-to-date hdf5 snapshot.  The most recent daily-build hdf5 snapshot was 3 weeks ago, and the most recent from a release workflow was Mar 12.