### PR TITLE
Update binary test offsets and don't exclude H5ZFP_UD-h5dump-ud_mesh_convert test

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -181,7 +181,7 @@
       ],
       "filter": {
         "exclude": {
-          "name": "H5DUMP-h5ex_d_granularbr|H5ZFP_UD-h5dump-ud_mesh_convert"
+          "name": "H5DUMP-h5ex_d_granularbr"
         }
       }
     },
@@ -198,11 +198,6 @@
       "inherits": [
         "ci-macos-arm64-Release-Clang"
       ],
-      "filter": {
-        "exclude": {
-          "name": "H5ZFP_UD-h5dump-ud_mesh_convert"
-        }
-      },
       "execution": {
         "noTestsAction": "error",
         "timeout": 180,
@@ -221,12 +216,6 @@
       "configurePreset": "ci-StdShar-GNUC",
       "inherits": [
         "ci-x64-Release-GNUC"
-      ],
-      "filter": {
-        "exclude": {
-          "name": "H5ZFP_UD-h5dump-ud_mesh_convert"
-        }
-      }
     },
     {
       "name": "ci-StdShar-win-Intel",
@@ -236,7 +225,7 @@
       ],
       "filter": {
         "exclude": {
-          "name": "H5DUMP-h5ex_d_granularbr|H5ZFP_UD-h5dump-ud_mesh_convert"
+          "name": "H5DUMP-h5ex_d_granularbr"
         }
       },
       "condition": {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -216,6 +216,7 @@
       "configurePreset": "ci-StdShar-GNUC",
       "inherits": [
         "ci-x64-Release-GNUC"
+      ]
     },
     {
       "name": "ci-StdShar-win-Intel",

--- a/config/cmake/binex/example/testfiles/h5repack_layout.h5-ud_pl_blosc_convert.ddl
+++ b/config/cmake/binex/example/testfiles/h5repack_layout.h5-ud_pl_blosc_convert.ddl
@@ -50,7 +50,7 @@ GROUP "/" {
       STORAGE_LAYOUT {
          CONTIGUOUS
          SIZE 3200
-         OFFSET 9264
+         OFFSET 9017
       }
       FILTERS {
          NONE
@@ -69,7 +69,7 @@ GROUP "/" {
       STORAGE_LAYOUT {
          CONTIGUOUS
          SIZE 3200
-         OFFSET 14512
+         OFFSET 14265
       }
       FILTERS {
          NONE
@@ -124,7 +124,7 @@ GROUP "/" {
       STORAGE_LAYOUT {
          CONTIGUOUS
          SIZE 3200
-         OFFSET 27000
+         OFFSET 26765
       }
       FILTERS {
          NONE

--- a/config/cmake/binex/example/testfiles/h5repack_layout.h5-ud_pl_bz2_convert.ddl
+++ b/config/cmake/binex/example/testfiles/h5repack_layout.h5-ud_pl_bz2_convert.ddl
@@ -28,7 +28,7 @@ GROUP "/" {
       STORAGE_LAYOUT {
          CONTIGUOUS
          SIZE 3200
-         OFFSET 8120
+         OFFSET 7881
       }
       FILTERS {
          NONE
@@ -47,7 +47,7 @@ GROUP "/" {
       STORAGE_LAYOUT {
          CONTIGUOUS
          SIZE 3200
-         OFFSET 11320
+         OFFSET 11081
       }
       FILTERS {
          NONE
@@ -66,7 +66,7 @@ GROUP "/" {
       STORAGE_LAYOUT {
          CONTIGUOUS
          SIZE 3200
-         OFFSET 14520
+         OFFSET 14281
       }
       FILTERS {
          NONE
@@ -121,7 +121,7 @@ GROUP "/" {
       STORAGE_LAYOUT {
          CONTIGUOUS
          SIZE 3200
-         OFFSET 26208
+         OFFSET 25981
       }
       FILTERS {
          NONE

--- a/config/cmake/binex/example/testfiles/h5repack_layout.h5-ud_pl_lz4_convert.ddl
+++ b/config/cmake/binex/example/testfiles/h5repack_layout.h5-ud_pl_lz4_convert.ddl
@@ -72,7 +72,7 @@ GROUP "/" {
       STORAGE_LAYOUT {
          CONTIGUOUS
          SIZE 3200
-         OFFSET 23921
+         OFFSET 23666
       }
       FILTERS {
          NONE
@@ -127,7 +127,7 @@ GROUP "/" {
       STORAGE_LAYOUT {
          CONTIGUOUS
          SIZE 3200
-         OFFSET 35609
+         OFFSET 35366
       }
       FILTERS {
          NONE


### PR DESCRIPTION
H5ZFP_UD-h5dump-ud_mesh_convert test passes since hdf5_plugins and hdf5 are in synch.

These binary tests were failing because hdf5 code changed OFFSETs slightly
	 30 - H5PL_UD-h5dump-ud_pl_bz2_convert (Failed)
	 33 - H5PL_UD-h5dump-ud_pl_blosc_convert (Failed)
	 36 - H5PL_UD-h5dump-ud_pl_lz4_convert (Failed)