### PR TITLE
Add encoder selector to LZ4 plugin 32004 via cd_values[1]

### DIFF
--- a/LZ4/LZ4_HDF5_format.md
+++ b/LZ4/LZ4_HDF5_format.md
@@ -43,3 +43,13 @@ The size of the data field stored in big endian signed 32 bit format.
 
 If this value is equal to the known decompressed size of the block, the data is stored
 not compressed. Otherwise, the data is in the [LZ4 Block](https://github.com/lz4/lz4/blob/v1.10.0/doc/lz4_Block_format.md) format.
+
+## Encoder choice
+
+The on-disk format above is independent of the encoder the writer used.
+The plugin's `cd_values[1]` selects between `LZ4_compress_default`
+(value `0`, the default), `LZ4_compress_HC` (positive value, HC level),
+and accelerated `LZ4_compress_fast` (negative value, acceleration =
+`-cd_values[1]`). All three produce LZ4 Block payloads that the same
+`LZ4_decompress_safe` path reads, so files written with any encoder
+choice are bitstream-compatible with readers that only know the default.

--- a/LZ4/LZ4_HDF5_format.md
+++ b/LZ4/LZ4_HDF5_format.md
@@ -43,13 +43,3 @@ The size of the data field stored in big endian signed 32 bit format.
 
 If this value is equal to the known decompressed size of the block, the data is stored
 not compressed. Otherwise, the data is in the [LZ4 Block](https://github.com/lz4/lz4/blob/v1.10.0/doc/lz4_Block_format.md) format.
-
-## Encoder choice
-
-The on-disk format above is independent of the encoder the writer used.
-The plugin's `cd_values[1]` selects between `LZ4_compress_default`
-(value `0`, the default), `LZ4_compress_HC` (positive value, HC level),
-and accelerated `LZ4_compress_fast` (negative value, acceleration =
-`-cd_values[1]`). All three produce LZ4 Block payloads that the same
-`LZ4_decompress_safe` path reads, so files written with any encoder
-choice are bitstream-compatible with readers that only know the default.

--- a/LZ4/README.txt
+++ b/LZ4/README.txt
@@ -20,3 +20,30 @@ Example:
     folders:
     set(ENV{HDF5_ROOT} "/temp/hdf5")
     set(ENV{LZ4_ROOT} "/temp/lz4")
+
+Filter parameters (cd_values[])
+-------------------------------
+
+cd_values[0] -- block size (unchanged). 0 or absent selects the plugin
+default (1 GiB).
+
+cd_values[1] -- encoder selector (optional). Stored as unsigned int but
+interpreted as a signed int:
+
+      0  : LZ4_compress_default       (legacy behavior, the default)
+    > 0  : LZ4HC level, clamped to [LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX]
+           (currently [2, 12]); 9 is the LZ4HC default.
+    < 0  : fast-encoder acceleration = -cd_values[1], lower-bounded at 1
+           and clamped by liblz4 internally at LZ4_ACCELERATION_MAX
+           (currently 65537).
+
+Because the slot is unsigned on disk, a negative encoder value is stored
+as its two's-complement bit pattern. For example, acceleration 8 is
+written as cd_values[1] = -8 and "h5dump -p" displays the slot as the
+unsigned decimal 4294967288. The plugin casts back to int when reading.
+
+cd_values[1] only affects writes. The on-disk chunk format is unchanged:
+LZ4HC, accelerated fast LZ4, and the default encoder all produce LZ4
+Block payloads that the existing reader (LZ4_decompress_safe) decodes
+without modification. Files written by the older plugin (cd_nelmts <= 1)
+are read by the new plugin identically.

--- a/LZ4/README.txt
+++ b/LZ4/README.txt
@@ -28,19 +28,27 @@ cd_values[0] -- block size (unchanged). 0 or absent selects the plugin
 default (1 GiB).
 
 cd_values[1] -- encoder selector (optional). Stored as unsigned int but
-interpreted as a signed int:
+interpreted as a signed int. It follows the same signed compression-level
+convention as liblz4's lz4frame API, so a value means the same thing here
+as it does everywhere else in the LZ4 ecosystem:
 
-      0  : LZ4_compress_default       (legacy behavior, the default)
-    > 0  : LZ4HC level, clamped to [LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX]
-           (currently [2, 12]); 9 is the LZ4HC default.
-    < 0  : fast-encoder acceleration = -cd_values[1], lower-bounded at 1
-           and clamped by liblz4 internally at LZ4_ACCELERATION_MAX
-           (currently 65537).
+    >= 2  : LZ4HC level (2..12); values above 12 are clamped to 12.
+            9 is the LZ4HC default and the recommended archival setting.
+   0 or 1 : default fast encoder (LZ4_compress_default; acceleration 1).
+     < 0  : fast encoder with acceleration = -cd_values[1] + 1, so -1 is
+            acceleration 2, -2 is acceleration 3, and so on. Values below
+            -65536 are clamped to -65536 (acceleration LZ4_ACCELERATION_MAX,
+            currently 65537).
 
-Because the slot is unsigned on disk, a negative encoder value is stored
-as its two's-complement bit pattern. For example, acceleration 8 is
-written as cd_values[1] = -8 and "h5dump -p" displays the slot as the
-unsigned decimal 4294967288. The plugin casts back to int when reading.
+Note the negative side is offset by one: acceleration 1 is the default
+(0 or 1), so the first faster-than-default step is -1 (acceleration 2).
+To request a specific acceleration A (A >= 2), set cd_values[1] = 1 - A.
+For example, acceleration 8 -> cd_values[1] = -7; acceleration 9 -> -8.
+
+Because the slot is unsigned on disk, a negative value is stored as its
+two's-complement bit pattern. For example, cd_values[1] = -8 (acceleration
+9) is stored as 4294967288, which is what "h5dump -p" displays. The plugin
+casts the slot back to int when reading.
 
 cd_values[1] only affects writes. The on-disk chunk format is unchanged:
 LZ4HC, accelerated fast LZ4, and the default encoder all produce LZ4

--- a/LZ4/example/h5ex_d_lz4.c
+++ b/LZ4/example/h5ex_d_lz4.c
@@ -34,8 +34,8 @@
 #define H5Z_FILTER_LZ4 32004
 
 static int
-write_lz4_dataset(hid_t file_id, hid_t space_id, const hsize_t chunk[2], const char *name,
-                  size_t nelmts, const unsigned int *cd_values, const int *wdata)
+write_lz4_dataset(hid_t file_id, hid_t space_id, const hsize_t chunk[2], const char *name, size_t nelmts,
+                  const unsigned int *cd_values, const int *wdata)
 {
     hid_t dcpl_id = H5I_INVALID_HID;
     hid_t dset_id = H5I_INVALID_HID;
@@ -47,8 +47,7 @@ write_lz4_dataset(hid_t file_id, hid_t space_id, const hsize_t chunk[2], const c
         goto done;
     if (H5Pset_chunk(dcpl_id, 2, chunk) < 0)
         goto done;
-    if ((dset_id = H5Dcreate(file_id, name, H5T_STD_I32LE, space_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) <
-        0)
+    if ((dset_id = H5Dcreate(file_id, name, H5T_STD_I32LE, space_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) < 0)
         goto done;
     if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, wdata) < 0)
         goto done;
@@ -133,8 +132,7 @@ run_encoder_check(const int *wdata, int expected_max, const hsize_t dims[2], con
     printf("....Encoder selector check ........\n");
     printf("  DS_HC9:  round-trip OK\n");
     printf("  DS_HC12: round-trip OK\n");
-    printf("  DS_HC99: round-trip OK; storage equals DS_HC12: %s\n",
-           size_hc99 == size_hc12 ? "yes" : "no");
+    printf("  DS_HC99: round-trip OK; storage equals DS_HC12: %s\n", size_hc99 == size_hc12 ? "yes" : "no");
 
     if (size_hc99 == size_hc12)
         ret = 0;

--- a/LZ4/example/h5ex_d_lz4.c
+++ b/LZ4/example/h5ex_d_lz4.c
@@ -20,17 +20,131 @@
 
  ************************************************************/
 
-#include "hdf5.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include "hdf5.h"
 
 #define FILENAME       "h5ex_d_lz4.h5"
+#define FILENAME_ENC   "h5ex_d_lz4_enc.h5"
 #define DATASET        "DS1"
 #define DIM0           32
 #define DIM1           64
 #define CHUNK0         4
 #define CHUNK1         8
 #define H5Z_FILTER_LZ4 32004
+
+static int
+write_lz4_dataset(hid_t file_id, hid_t space_id, const hsize_t chunk[2], const char *name,
+                  size_t nelmts, const unsigned int *cd_values, const int *wdata)
+{
+    hid_t dcpl_id = H5I_INVALID_HID;
+    hid_t dset_id = H5I_INVALID_HID;
+    int   ret     = -1;
+
+    if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) < 0)
+        goto done;
+    if (H5Pset_filter(dcpl_id, H5Z_FILTER_LZ4, H5Z_FLAG_MANDATORY, nelmts, cd_values) < 0)
+        goto done;
+    if (H5Pset_chunk(dcpl_id, 2, chunk) < 0)
+        goto done;
+    if ((dset_id = H5Dcreate(file_id, name, H5T_STD_I32LE, space_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT)) <
+        0)
+        goto done;
+    if (H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, wdata) < 0)
+        goto done;
+
+    ret = 0;
+done:
+    if (dset_id >= 0)
+        H5Dclose(dset_id);
+    if (dcpl_id >= 0)
+        H5Pclose(dcpl_id);
+    return ret;
+}
+
+static int
+read_and_check(hid_t file_id, const char *name, int expected_max, hsize_t *out_storage)
+{
+    hid_t   dset_id = H5I_INVALID_HID;
+    int     rdata[DIM0][DIM1];
+    int     i, j, max_seen;
+    hsize_t storage = 0;
+    int     ret     = -1;
+
+    if ((dset_id = H5Dopen(file_id, name, H5P_DEFAULT)) < 0)
+        goto done;
+    if (H5Dread(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rdata[0]) < 0)
+        goto done;
+    storage  = H5Dget_storage_size(dset_id);
+    max_seen = rdata[0][0];
+    for (i = 0; i < DIM0; i++)
+        for (j = 0; j < DIM1; j++)
+            if (max_seen < rdata[i][j])
+                max_seen = rdata[i][j];
+    if (max_seen != expected_max)
+        goto done;
+    if (out_storage)
+        *out_storage = storage;
+    ret = 0;
+done:
+    if (dset_id >= 0)
+        H5Dclose(dset_id);
+    return ret;
+}
+
+static int
+run_encoder_check(const int *wdata, int expected_max, const hsize_t dims[2], const hsize_t chunk[2])
+{
+    hid_t              file_id  = H5I_INVALID_HID;
+    hid_t              space_id = H5I_INVALID_HID;
+    hsize_t            size_hc9 = 0, size_hc12 = 0, size_hc99 = 0;
+    const unsigned int cd_hc9[2]  = {0, 9};
+    const unsigned int cd_hc12[2] = {0, 12};
+    const unsigned int cd_hc99[2] = {0, 99};
+    int                ret        = -1;
+
+    if ((file_id = H5Fcreate(FILENAME_ENC, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto done;
+    if ((space_id = H5Screate_simple(2, dims, NULL)) < 0)
+        goto done;
+
+    if (write_lz4_dataset(file_id, space_id, chunk, "DS_HC9", 2, cd_hc9, wdata) < 0)
+        goto done;
+    if (write_lz4_dataset(file_id, space_id, chunk, "DS_HC12", 2, cd_hc12, wdata) < 0)
+        goto done;
+    if (write_lz4_dataset(file_id, space_id, chunk, "DS_HC99", 2, cd_hc99, wdata) < 0)
+        goto done;
+
+    H5Sclose(space_id);
+    space_id = H5I_INVALID_HID;
+    H5Fclose(file_id);
+    file_id = H5I_INVALID_HID;
+
+    if ((file_id = H5Fopen(FILENAME_ENC, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
+        goto done;
+
+    if (read_and_check(file_id, "DS_HC9", expected_max, &size_hc9) < 0)
+        goto done;
+    if (read_and_check(file_id, "DS_HC12", expected_max, &size_hc12) < 0)
+        goto done;
+    if (read_and_check(file_id, "DS_HC99", expected_max, &size_hc99) < 0)
+        goto done;
+
+    printf("....Encoder selector check ........\n");
+    printf("  DS_HC9:  round-trip OK\n");
+    printf("  DS_HC12: round-trip OK\n");
+    printf("  DS_HC99: round-trip OK; storage equals DS_HC12: %s\n",
+           size_hc99 == size_hc12 ? "yes" : "no");
+
+    if (size_hc99 == size_hc12)
+        ret = 0;
+done:
+    if (space_id >= 0)
+        H5Sclose(space_id);
+    if (file_id >= 0)
+        H5Fclose(file_id);
+    return ret;
+}
 
 int
 main(void)
@@ -214,6 +328,11 @@ main(void)
     avail = H5Zfilter_avail(H5Z_FILTER_LZ4);
     if (avail)
         printf("lz4 filter is available now since H5Dread triggered loading of the filter.\n");
+
+    if (run_encoder_check(wdata[0], max, dims, chunk) < 0) {
+        printf("Encoder selector check FAILED\n");
+        goto done;
+    }
 
     ret_value = 0;
 

--- a/LZ4/example/h5ex_d_lz4.c
+++ b/LZ4/example/h5ex_d_lz4.c
@@ -100,6 +100,7 @@ run_encoder_check(const int *wdata, int expected_max, const hsize_t dims[2], con
     const unsigned int cd_hc9[2]  = {0, 9};
     const unsigned int cd_hc12[2] = {0, 12};
     const unsigned int cd_hc99[2] = {0, 99};
+    const unsigned int cd_fast[2] = {0, (unsigned int)(-8)}; /* fast, acceleration 9 */
     int                ret        = -1;
 
     if ((file_id = H5Fcreate(FILENAME_ENC, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -112,6 +113,8 @@ run_encoder_check(const int *wdata, int expected_max, const hsize_t dims[2], con
     if (write_lz4_dataset(file_id, space_id, chunk, "DS_HC12", 2, cd_hc12, wdata) < 0)
         goto done;
     if (write_lz4_dataset(file_id, space_id, chunk, "DS_HC99", 2, cd_hc99, wdata) < 0)
+        goto done;
+    if (write_lz4_dataset(file_id, space_id, chunk, "DS_FAST", 2, cd_fast, wdata) < 0)
         goto done;
 
     H5Sclose(space_id);
@@ -128,11 +131,14 @@ run_encoder_check(const int *wdata, int expected_max, const hsize_t dims[2], con
         goto done;
     if (read_and_check(file_id, "DS_HC99", expected_max, &size_hc99) < 0)
         goto done;
+    if (read_and_check(file_id, "DS_FAST", expected_max, NULL) < 0)
+        goto done;
 
     printf("....Encoder selector check ........\n");
     printf("  DS_HC9:  round-trip OK\n");
     printf("  DS_HC12: round-trip OK\n");
     printf("  DS_HC99: round-trip OK; storage equals DS_HC12: %s\n", size_hc99 == size_hc12 ? "yes" : "no");
+    printf("  DS_FAST: round-trip OK\n");
 
     if (size_hc99 == size_hc12)
         ret = 0;

--- a/LZ4/example/testfiles/h5ex_d_lz4.tst
+++ b/LZ4/example/testfiles/h5ex_d_lz4.tst
@@ -9,3 +9,7 @@ Filter info is available from the dataset creation property
 ....Reading lz4 compressed data ................
 Maximum value in DS1 is 1890
 lz4 filter is available now since H5Dread triggered loading of the filter.
+....Encoder selector check ........
+  DS_HC9:  round-trip OK
+  DS_HC12: round-trip OK
+  DS_HC99: round-trip OK; storage equals DS_HC12: yes

--- a/LZ4/example/testfiles/h5ex_d_lz4.tst
+++ b/LZ4/example/testfiles/h5ex_d_lz4.tst
@@ -13,3 +13,4 @@ lz4 filter is available now since H5Dread triggered loading of the filter.
   DS_HC9:  round-trip OK
   DS_HC12: round-trip OK
   DS_HC99: round-trip OK; storage equals DS_HC12: yes
+  DS_FAST: round-trip OK

--- a/LZ4/src/H5Zlz4.c
+++ b/LZ4/src/H5Zlz4.c
@@ -239,9 +239,8 @@ H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts, const unsigned int cd_value
             if (nbytes - origWritten < blockSize) /* the last block may be < blockSize */
                 blockSize = nbytes - origWritten;
 
-            compBlockSize = lz4_encode(
-                rpos, roBuf + 4, (int)blockSize,
-                LZ4_compressBound((int)blockSize), encoderParam); /// reserve space for compBlockSize
+            compBlockSize = lz4_encode(rpos, roBuf + 4, (int)blockSize, LZ4_compressBound((int)blockSize),
+                                       encoderParam); /// reserve space for compBlockSize
             if (!compBlockSize)
                 goto error;
             if (compBlockSize >= blockSize) /* compression did not save any space, do a memcpy instead */

--- a/LZ4/src/H5Zlz4.c
+++ b/LZ4/src/H5Zlz4.c
@@ -54,6 +54,7 @@
 
 #include "H5PLextern.h"
 #include "lz4.h"
+#include "lz4hc.h"
 
 static size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts, const unsigned int cd_values[],
                              size_t nbytes, size_t *buf_size, void **buf);
@@ -98,6 +99,29 @@ const void *
 H5PLget_plugin_info(void)
 {
     return H5Z_LZ4;
+}
+
+static int
+lz4_encode(const char *src, char *dst, int srcSz, int dstCap, int encoderParam)
+{
+    if (encoderParam > 0) {
+        int level = encoderParam;
+        if (level < LZ4HC_CLEVEL_MIN)
+            level = LZ4HC_CLEVEL_MIN;
+        if (level > LZ4HC_CLEVEL_MAX)
+            level = LZ4HC_CLEVEL_MAX;
+        return LZ4_compress_HC(src, dst, srcSz, dstCap, level);
+    }
+    else if (encoderParam < 0) {
+        /* Widen before negating so encoderParam == INT_MIN cannot overflow. */
+        long accel = -(long)encoderParam;
+        if (accel < 1)
+            accel = 1;
+        /* No explicit upper clamp: LZ4_compress_fast() clamps internally to
+         * LZ4_ACCELERATION_MAX (currently 65537; see lz4.c). */
+        return LZ4_compress_fast(src, dst, srcSz, dstCap, (int)accel);
+    }
+    return LZ4_compress_default(src, dst, srcSz, dstCap);
 }
 
 static size_t
@@ -173,6 +197,7 @@ H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts, const unsigned int cd_value
         size_t    maxDestSize;
         char     *rpos;  /* pointer to current read position */
         char     *roBuf; /* pointer to current write position */
+        int       encoderParam;
 
         if (nbytes > INT32_MAX) {
             /* can only compress chunks up to 2GB */
@@ -185,6 +210,7 @@ H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts, const unsigned int cd_value
         else {
             blockSize = DEFAULT_BLOCK_SIZE;
         }
+        encoderParam = (cd_nelmts > 1) ? (int)cd_values[1] : 0;
         if (blockSize > nbytes) {
             blockSize = nbytes;
         }
@@ -213,8 +239,9 @@ H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts, const unsigned int cd_value
             if (nbytes - origWritten < blockSize) /* the last block may be < blockSize */
                 blockSize = nbytes - origWritten;
 
-            compBlockSize = LZ4_compress_default(
-                rpos, roBuf + 4, blockSize, LZ4_compressBound(blockSize)); /// reserve space for compBlockSize
+            compBlockSize = lz4_encode(
+                rpos, roBuf + 4, (int)blockSize,
+                LZ4_compressBound((int)blockSize), encoderParam); /// reserve space for compBlockSize
             if (!compBlockSize)
                 goto error;
             if (compBlockSize >= blockSize) /* compression did not save any space, do a memcpy instead */

--- a/LZ4/src/H5Zlz4.c
+++ b/LZ4/src/H5Zlz4.c
@@ -101,27 +101,32 @@ H5PLget_plugin_info(void)
     return H5Z_LZ4;
 }
 
+/* liblz4 caps fast-mode acceleration at LZ4_ACCELERATION_MAX internally but
+ * does not expose the macro in lz4.h; mirror the value from lz4.c here. */
+#ifndef LZ4_ACCELERATION_MAX
+#define LZ4_ACCELERATION_MAX 65537
+#endif
+
 static int
 lz4_encode(const char *src, char *dst, int srcSz, int dstCap, int encoderParam)
 {
-    if (encoderParam > 0) {
-        int level = encoderParam;
-        if (level < LZ4HC_CLEVEL_MIN)
-            level = LZ4HC_CLEVEL_MIN;
-        if (level > LZ4HC_CLEVEL_MAX)
-            level = LZ4HC_CLEVEL_MAX;
-        return LZ4_compress_HC(src, dst, srcSz, dstCap, level);
+    /* Mirror liblz4's lz4frame compressionLevel convention:
+     *   >= LZ4HC_CLEVEL_MIN (2) -> LZ4HC at that level
+     *   0 or 1                  -> default fast (acceleration 1)
+     *   < 0                     -> fast, acceleration = -encoderParam + 1
+     * Clamp to the usable range first so the acceleration arithmetic cannot
+     * overflow. */
+    if (encoderParam > LZ4HC_CLEVEL_MAX)
+        encoderParam = LZ4HC_CLEVEL_MAX;
+    if (encoderParam < -(LZ4_ACCELERATION_MAX - 1))
+        encoderParam = -(LZ4_ACCELERATION_MAX - 1);
+
+    if (encoderParam >= LZ4HC_CLEVEL_MIN)
+        return LZ4_compress_HC(src, dst, srcSz, dstCap, encoderParam);
+    else {
+        int acceleration = (encoderParam < 0) ? -encoderParam + 1 : 1;
+        return LZ4_compress_fast(src, dst, srcSz, dstCap, acceleration);
     }
-    else if (encoderParam < 0) {
-        /* Widen before negating so encoderParam == INT_MIN cannot overflow. */
-        long accel = -(long)encoderParam;
-        if (accel < 1)
-            accel = 1;
-        /* No explicit upper clamp: LZ4_compress_fast() clamps internally to
-         * LZ4_ACCELERATION_MAX (currently 65537; see lz4.c). */
-        return LZ4_compress_fast(src, dst, srcSz, dstCap, (int)accel);
-    }
-    return LZ4_compress_default(src, dst, srcSz, dstCap);
 }
 
 static size_t

--- a/LZ4/src/H5Zlz4.c
+++ b/LZ4/src/H5Zlz4.c
@@ -203,6 +203,8 @@ H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts, const unsigned int cd_value
         char     *rpos;  /* pointer to current read position */
         char     *roBuf; /* pointer to current write position */
         int       encoderParam;
+        int       blockBound;
+        size_t    perBlock;
 
         if (nbytes > INT32_MAX) {
             /* can only compress chunks up to 2GB */
@@ -219,8 +221,25 @@ H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts, const unsigned int cd_value
         if (blockSize > nbytes) {
             blockSize = nbytes;
         }
-        nBlocks     = (nbytes - 1) / blockSize + 1;
-        maxDestSize = nBlocks * LZ4_compressBound(blockSize) + 4 + 8 + nBlocks * 4;
+        nBlocks = (nbytes - 1) / blockSize + 1;
+
+        /* LZ4_compressBound returns 0 when blockSize exceeds LZ4_MAX_INPUT_SIZE,
+         * which sits ~32 MiB below INT32_MAX -- so a block in that gap passes the
+         * nbytes check above. Reject it before sizing the output buffer; this
+         * also guarantees the (int)blockSize casts below stay in range. */
+        blockBound = LZ4_compressBound((int)blockSize);
+        if (blockBound <= 0)
+            goto error;
+
+        /* Output size = nBlocks * (blockBound + 4-byte block header) + 12-byte
+         * chunk header. Guard the size_t arithmetic before malloc: a tiny
+         * blockSize makes nBlocks huge, and on a 32-bit platform the product
+         * can wrap, yielding an undersized buffer and a heap overflow in the
+         * write loop below. blockBound > 0 here, so perBlock cannot be zero. */
+        perBlock = (size_t)blockBound + 4;
+        if (nBlocks > (SIZE_MAX - 12) / perBlock)
+            goto error;
+        maxDestSize = nBlocks * perBlock + 12;
         if (NULL == (outBuf = malloc(maxDestSize))) {
             goto error;
         }

--- a/docs/RegisteredFilterPlugins.md
+++ b/docs/RegisteredFilterPlugins.md
@@ -266,22 +266,25 @@ The filter's source code is available from https://github.com/lz4/lz4.
 
 #### Plugin ID `32004` Information
 
-Number of `cd_values[]` parameters is one (`cd_nelmts = 1`).
+Number of `cd_values[]` parameters is up to two (`cd_nelmts <= 2`).
 
 | `cd_values[]` | Description |
 |---|---|
 | `[0]` | Block size in bytes at most 2,113,929,216 bytes. Default is 1 GiB (1,073,741,824 bytes). (optional) |
+| `[1]` | Encoder selector, stored unsigned but interpreted as signed `int`. `0` (default) selects `LZ4_compress_default`. A positive value selects `LZ4_compress_HC` at that level, clamped to `[LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX]` (currently `[2, 12]`; `9` is the LZ4HC default). A negative value selects `LZ4_compress_fast` with acceleration = `-cd_values[1]`, lower-bounded at `1` and clamped by liblz4 internally at `LZ4_ACCELERATION_MAX` (currently `65537`). Negative values store as their two's-complement bit pattern, so e.g. acceleration `8` prints as `4294967288` in `h5dump -p`. The on-disk chunk format is unchanged across all three encoders. (optional) |
 
  The description of the chunk binary format produced by this plugin is at [LZ4_HDF5_format.md](https://github.com/HDFGroup/hdf5_plugins/blob/master/LZ4/LZ4_HDF5_format.md).
 
-`h5repack` example for the `--filter` option: `<objects list>:UD=32004,0,0`.
+`h5repack` examples for the `--filter` option:
+* default encoder, default block size: `<objects list>:UD=32004,0,0`
+* LZ4HC level 9 (archival), default block size: `<objects list>:UD=32004,0,2,0,9`
 
-https://github.com/HDFGroup/hdf5_plugins/tree/master/LZ4/src
+https://github.com/HDFGroup/hdf5_plugins/tree/master/LZ4/
 
 ##### Contact
 
-Michael Rissi (Dectris Ltd.)<br/>
-Email: michael dot rissi at dectris dot com
+HDF Group Helpdesk<br/>
+Email: help at hdfgroup dot org
 
 ---
 

--- a/docs/RegisteredFilterPlugins.md
+++ b/docs/RegisteredFilterPlugins.md
@@ -271,8 +271,13 @@ Number of `cd_values[]` parameters is up to two (`cd_nelmts <= 2`).
 | `cd_values[]` | Description |
 |---|---|
 | `[0]` | Block size in bytes at most 2,113,929,216 bytes. Default is 1 GiB (1,073,741,824 bytes). (optional) |
-| `[1]` | Encoder selector, stored unsigned but interpreted as signed `int`. `0` (default) selects `LZ4_compress_default`. A positive value selects `LZ4_compress_HC` at that level, clamped to `[LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX]` (currently `[2, 12]`; `9` is the LZ4HC default). A negative value selects `LZ4_compress_fast` with acceleration = `-cd_values[1]`, lower-bounded at `1` and clamped by liblz4 internally at `LZ4_ACCELERATION_MAX` (currently `65537`). Negative values store as their two's-complement bit pattern, so e.g. acceleration `8` prints as `4294967288` in `h5dump -p`. The on-disk chunk format is unchanged across all three encoders. (optional) |
+| `[1]` | Encoder selector, stored unsigned but interpreted as signed `int`. Negative values store as their two's-complement bit pattern, so `-8` prints as `4294967288` in `h5dump -p`. (optional) |
 
+`cd_values[1]` follows liblz4's `lz4frame` signed compression-level convention:
+
+ * `>= 2` selects `LZ4_compress_HC` at that level (`2..12`; higher values clamp to `12`, and `9` is the LZ4HC default).
+ * `0` or `1` selects the default fast encoder (`LZ4_compress_default`, acceleration `1`).
+ * A negative value selects `LZ4_compress_fast` with acceleration = `-cd_values[1] + 1` (so `-1` is acceleration `2`), clamped below at `-65536` (acceleration `LZ4_ACCELERATION_MAX`, currently `65537`). To request a specific acceleration `A >= 2`, set `cd_values[1] = 1 - A` (e.g. acceleration `9` → `-8`).
  The description of the chunk binary format produced by this plugin is at [LZ4_HDF5_format.md](https://github.com/HDFGroup/hdf5_plugins/blob/master/LZ4/LZ4_HDF5_format.md).
 
 `h5repack` examples for the `--filter` option:


### PR DESCRIPTION
A new signed `cd_values[1]` slot selects LZ4HC level (positive), fast-encoder acceleration (negative), or the legacy LZ4_compress_default (zero/absent), with HC level clamped to [`LZ4HC_CLEVEL_MIN`, `LZ4HC_CLEVEL_MAX`]. The on-disk chunk format is unchanged, so existing archives and the reverse filter continue to work without modification.

Closes #244.